### PR TITLE
Emit tooltip information as output

### DIFF
--- a/src/components/histogram/histogram.component.css
+++ b/src/components/histogram/histogram.component.css
@@ -256,6 +256,12 @@
   z-index: 30000;
 }
 
+.histogram__area_circle
+{
+  fill: #7fa5a1;
+  stroke: #7fa5a1;
+}
+
 .swimlane_legend_color, .swimlane_legend_value {
   display: inline-block;
   font-size: 0.7em;

--- a/src/components/histogram/histogram.component.html
+++ b/src/components/histogram/histogram.component.html
@@ -41,28 +41,6 @@
       <div class="histogram__description__endvalue"><span *ngIf="histogram.histogramParams.dataLength > 1" class="histogram__description__endvalue--background">{{histogram.histogramParams.endValue}}</span></div>
     </div>
   </div>
-  <div *ngIf="chartType !== ChartType.swimlane">
-    <div class="histogram__tooltip" *ngIf="histogram.histogramParams.tooltip.isShown && !histogram.histogramParams.tooltip.isRightSide" [style.left.px]="histogram.histogramParams.tooltip.xPosition" [style.top.px]="histogram.histogramParams.tooltip.yPosition">
-      <div class="histogram__tooltip-xcontent-wrapper">
-        <span class="histogram__tooltip-content histogram__tooltip-xlabel">{{(chartXLabel | translate)}}</span>
-        <span class="histogram__tooltip-content histogram__tooltip-xcontent">{{ histogram.histogramParams.tooltip.xContent}} {{xUnit | translate}}</span>
-      </div>
-      <div class="histogram__tooltip-ycontent-wrapper">
-        <span class="histogram__tooltip-content histogram__tooltip-ylabel">{{(chartTitle | translate)}}</span>
-        <span class="histogram__tooltip-content histogram__tooltip-ycontent">{{ histogram.histogramParams.tooltip.yContent}} {{yUnit | translate}}</span>
-      </div>
-    </div>
-    <div class="histogram__tooltip" *ngIf="histogram.histogramParams.tooltip.isShown && histogram.histogramParams.tooltip.isRightSide" [style.right.px]="histogram.histogramParams.tooltip.xPosition" [style.top.px]="histogram.histogramParams.tooltip.yPosition">
-      <div class="histogram__tooltip-xcontent-wrapper">
-        <span class="histogram__tooltip-content histogram__tooltip-xlabel">{{(chartXLabel | translate)}}</span>
-        <span class="histogram__tooltip-content histogram__tooltip-xcontent">{{ histogram.histogramParams.tooltip.xContent}} {{xUnit | translate}}</span>
-      </div>
-      <div class="histogram__tooltip-ycontent-wrapper">
-        <span class="histogram__tooltip-content histogram__tooltip-ylabel">{{(chartTitle | translate)}}</span>
-        <span class="histogram__tooltip-content histogram__tooltip-ycontent">{{ histogram.histogramParams.tooltip.yContent}} {{yUnit | translate}}</span>
-      </div>
-    </div>
-  </div>
   <div *ngIf="chartType === ChartType.swimlane">
     <div class="histogram__tooltip" *ngIf="histogram.histogramParams.swimlaneXTooltip.isShown && !histogram.histogramParams.swimlaneXTooltip.isRightSide"
       [style.left.px]="histogram.histogramParams.swimlaneXTooltip.xPosition"   [style.bottom.px]="30">

--- a/src/components/histogram/histogram.component.ts
+++ b/src/components/histogram/histogram.component.ts
@@ -38,7 +38,8 @@ import {
 
 import * as histogramJsonSchema from './histogram.schema.json';
 import * as swimlaneJsonSchema from './swimlane.schema.json';
-import { HistogramData, SwimlaneData, SwimlaneRepresentation, SwimlaneOptions } from 'arlas-d3/histograms/utils/HistogramUtils';
+import { HistogramData, SwimlaneData, SwimlaneRepresentation, SwimlaneOptions,
+  HistogramTooltip } from 'arlas-d3/histograms/utils/HistogramUtils';
 import { TranslateService } from '@ngx-translate/core';
 
 /**
@@ -321,9 +322,14 @@ export class HistogramComponent implements OnInit, OnChanges, AfterViewChecked {
   @Output() public hoveredBucketEvent: Subject<Date | number> = new Subject<Date | number>();
   /**
    * @Output : Angular
-   * @description Emits the hovered bucket key (key as in HistogramData).
+   * @description Emits an event informing that the chart finished plotting.
    */
   @Output() public dataPlottedEvent: Subject<string> = new Subject<string>();
+  /**
+   * @Output : Angular
+   * @description Emits the hovered bucket information that can be exploited to display a tooltip
+   */
+  @Output() public tooltipEvent: Subject<HistogramTooltip> = new Subject<HistogramTooltip>();
 
   public histogram: AbstractHistogram;
   public ChartType = ChartType;
@@ -532,5 +538,12 @@ export class HistogramComponent implements OnInit, OnChanges, AfterViewChecked {
     this.histogram.histogramParams.moveDataByHalfInterval = this.applyOffsetOnAreaChart;
     this.histogram.histogramParams.selectedSwimlanes = this.selectedSwimlanes;
     this.histogram.histogramParams.selectedSwimlanesEvent = this.selectedSwimlanesEvent;
+    this.histogram.histogramParams.tooltipEvent.subscribe(t => {
+      t.xLabel = this.chartXLabel;
+      t.yLabel = this.chartTitle;
+      t.xUnit = this.xUnit;
+      t.yUnit = this.yUnit;
+      this.tooltipEvent.next(t);
+    });
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,7 +28,7 @@ export { PowerbarsComponent } from './components/powerbars/powerbars.component';
 export { PowerbarsModule } from './components/powerbars/powerbars.module';
 export { MetricComponent } from './components/metric/metric.component';
 export { MetricModule } from './components/metric/metric.module';
-export { ChartType, DataType, Position, SimpleNode, TreeNode, SwimlaneMode } from 'arlas-d3';
+export { ChartType, DataType, Position, SimpleNode, TreeNode, SwimlaneMode, HistogramTooltip } from 'arlas-d3';
 export { SortEnum } from './components/results/utils/enumerations/sortEnum';
 export { ModeEnum } from './components/results/utils/enumerations/modeEnum';
 export { CellBackgroundStyleEnum } from './components/results/utils/enumerations/cellBackgroundStyleEnum';


### PR DESCRIPTION
- the component doesn't display its tooltip itself (for area and bar charts)
- the swimlane keeps handling tooltips itself

Needs release of ARLAS-d3 before merge