### PR TITLE
Fix display of column header in resultlist

### DIFF
--- a/projects/arlas-components/src/lib/components/results/result-list/result-list.component.css
+++ b/projects/arlas-components/src/lib/components/results/result-list/result-list.component.css
@@ -28,6 +28,9 @@
   font-size: 0.9em;
   text-align: left;
   vertical-align: middle;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .resultlist__header--columns__sort {

--- a/projects/arlas-components/src/lib/components/results/result-list/result-list.component.html
+++ b/projects/arlas-components/src/lib/components/results/result-list/result-list.component.html
@@ -96,8 +96,8 @@
         <th *ngIf="!column.isIdField && !column.isToggleField"
             [style.max-width.px]="column.width"
             [style.min-width.px]="column.width"
-            class="resultlist__header--columns" >
-          <span>
+            class="resultlist__header--columns" matTooltip="{{column.columnName | translate}}{{column.dataType}}">
+          <span >
             {{column.columnName | translate}}{{column.dataType}}
           </span>
         </th>


### PR DESCRIPTION
Fix #623

Add text ellipsis and tooltip to see full name of column:

![Capture d’écran 2022-01-21 à 16 59 30](https://user-images.githubusercontent.com/7236202/150559540-017a4de3-60c8-434c-858b-fa7748d006ba.png)

