### PR TITLE
Check if layers are already in a visualisation set

### DIFF
--- a/projects/arlas-components/src/lib/components/mapgl/mapgl.component.ts
+++ b/projects/arlas-components/src/lib/components/mapgl/mapgl.component.ts
@@ -913,15 +913,27 @@ export class MapglComponent implements OnInit, AfterViewInit, OnChanges, AfterCo
         });
 
         this.visibilityUpdater.subscribe(visibilityStatus => {
-          visibilityStatus.forEach((vs, l) => {
-            if (!vs) {
-              (this.map as mapboxgl.Map).setLayoutProperty(l, 'visibility', 'none');
-              this.setStrokeLayoutVisibility(l, 'none');
-              this.setScrollableLayoutVisibility(l, 'none');
+          visibilityStatus.forEach((visibilityStatus, l) => {
+            let layerInVisualisations = false;
+            if (!visibilityStatus) {
+              this.visualisationSetsConfig.forEach(v => {
+                const ls = new Set(v.layers);
+                if (!layerInVisualisations) {
+                  layerInVisualisations = ls.has(l);
+                }
+              });
+              if (layerInVisualisations) {
+                (this.map as mapboxgl.Map).setLayoutProperty(l, 'visibility', 'none');
+                this.setStrokeLayoutVisibility(l, 'none');
+                this.setScrollableLayoutVisibility(l, 'none');
+              }
             } else {
               let oneVisualisationEnabled = false;
               this.visualisationSetsConfig.forEach(v => {
                 const ls = new Set(v.layers);
+                if (!layerInVisualisations) {
+                  layerInVisualisations = ls.has(l);
+                }
                 if (ls.has(l) && v.enabled) {
                   oneVisualisationEnabled = true;
                   (this.map).setLayoutProperty(l, 'visibility', 'visible');
@@ -929,7 +941,7 @@ export class MapglComponent implements OnInit, AfterViewInit, OnChanges, AfterCo
                   this.setScrollableLayoutVisibility(l, 'visible');
                 }
               });
-              if (!oneVisualisationEnabled) {
+              if (!oneVisualisationEnabled && layerInVisualisations) {
                 (this.map).setLayoutProperty(l, 'visibility', 'none');
                 this.setStrokeLayoutVisibility(l, 'none');
                 this.setScrollableLayoutVisibility(l, 'none');


### PR DESCRIPTION
PR to fix gisaia/ARLAS-wui#529

The mapcomponent used to try to hide layers that are not affected to any visualisation set. Those layers are not recognised by the mapboxgl.map object and throws many errors in the console.