### PR TITLE
Include collection notion in legend data

### DIFF
--- a/projects/arlas-components/src/lib/components/mapgl-legend/mapgl-legend.component.ts
+++ b/projects/arlas-components/src/lib/components/mapgl-legend/mapgl-legend.component.ts
@@ -64,13 +64,13 @@ export class MapglLegendComponent implements OnInit, AfterViewInit, OnChanges {
   @Input() public enabled: boolean;
   /**
    * @Input : Angular
-   * @description Subject of [layerId, legendData] map. The map subscribes to it to keep
+   * @description Subject of [collection, [field, legendData]] map. The map subscribes to it to keep
    * the legend updated with the data displayed on the map.
    */
-  @Input() public legendUpdater: Subject<Map<string, LegendData>> = new Subject<Map<string, LegendData>>();
+  @Input() public legendUpdater: Subject<Map<string, Map<string, LegendData>>> = new Subject();
   /**
    * @Input : Angular
-   * @description Subject of [layerId, boolean] map. The map subscribes to it to keep
+   * @description Subject of [field, boolean] map. The map subscribes to it to keep
    * the legend updated with the visibility of the layer.
    */
   @Input() public visibilityUpdater: Subject<Map<string, boolean>> = new Subject();
@@ -106,8 +106,8 @@ export class MapglLegendComponent implements OnInit, AfterViewInit, OnChanges {
 
 
   public ngOnInit() {
-    this.legendUpdater.subscribe(legendData => {
-      this.legendData = legendData;
+    this.legendUpdater.subscribe(legendDataPerCollection => {
+      this.legendData = legendDataPerCollection.get(this.collection);
       this.drawLegends(this.visibleMode);
     });
     this.visibilityUpdater.subscribe(visibilityUpdater => {

--- a/projects/arlas-components/src/lib/components/mapgl/mapgl.component.ts
+++ b/projects/arlas-components/src/lib/components/mapgl/mapgl.component.ts
@@ -302,10 +302,10 @@ export class MapglComponent implements OnInit, AfterViewInit, OnChanges, AfterCo
 
   /**
    * @Input : Angular
-   * @description Subject of [layerId, legendData] map. The map subscribes to it to keep
+   * @description Subject of [collection, [field, legendData]] map. The map subscribes to it to keep
    * the legend updated with the data displayed on the map.
    */
-  @Input() public legendUpdater: Subject<Map<string, LegendData>> = new Subject<Map<string, LegendData>>();
+  @Input() public legendUpdater: Subject<Map<string, Map<string, LegendData>>> = new Subject();
 
   /**
    * @Input : Angular


### PR DESCRIPTION
- for now, if 2 collections display a 'count' or 'count:normalized', both will have the same count on the legebnd as there is no distinction between collections