### PR TITLE
fix(powerbars): variable size due to em + spacing for scrollbar

### DIFF
--- a/projects/arlas-components/src/lib/components/powerbars/powerbars.component.css
+++ b/projects/arlas-components/src/lib/components/powerbars/powerbars.component.css
@@ -50,9 +50,9 @@
   height: 100%;
   overflow-y: auto;
   overflow-x: hidden;
-  padding: 3px;
-  padding-top: 0;
+  padding: 0px 5px 3px 3px;
 }
+
 .powerbars__powerbar {
   position: relative;
   display: flex;
@@ -78,17 +78,17 @@
 .powerbars__powerbar--progression-default-colour /* @doc Style of all powerbars progression bar when no color is specified.*/ {
   background-color: #88c9c3;
   border: 1px solid #88c9c3;
-  height: 0.25em;
-  border-radius: calc(0.25em / 2);
+  height: 4px;
+  border-radius: 2px;
 }
 
 .powerbars__powerbar--progression /* @doc Style of all powerbars rightband when none of them is selected.*/ {
-  height: 0.25em;
-  border-radius: calc(0.25em / 2);
+  height: 4px;
+  border-radius: 2px;
 }
 
 .powerbar__powerbar--top-group {
-  padding-top: 0.75em;
+  padding-top: 10px;
   cursor: pointer;
   display: flex;
   align-items: center;
@@ -98,7 +98,7 @@
 
 .powerbar__powerbar--term /* @doc Style of terms.*/
 {
-  font-size: 0.75em;
+  font-size: 10px;
   width: 70%;
   cursor: pointer;
   position: absolute;
@@ -111,7 +111,7 @@
 
 .powerbar__powerbar--count /* @doc Style of counts.*/
 {
-  font-size: 0.75em;
+  font-size: 10px;
   width: 100%;
   cursor: pointer;
   position:relative;


### PR DESCRIPTION
There was an issue with the powerbars when integrated to other interfaces due to the use of em instead of px for sizes, as well as missing padding to leave a space between the text and the scrollbar