### PR TITLE
fix: error with undefined legendData

### DIFF
--- a/projects/arlas-components/src/lib/components/mapgl-legend/mapgl-legend.component.ts
+++ b/projects/arlas-components/src/lib/components/mapgl-legend/mapgl-legend.component.ts
@@ -389,7 +389,7 @@ export class MapglLegendComponent implements OnInit, AfterViewInit, OnChanges {
             colorLegend.minValue = legendData.get(field).minValue;
             colorLegend.maxValue = legendData.get(field).maxValue;
           // For heatmaps, the count is used to fetch data, so we use it for the legend
-          } else if (field === HEATMAP_DENSITY && legendData.get('count')) {
+          } else if (field === HEATMAP_DENSITY && legendData && legendData.get('count')) {
             colorLegend.minValue = legendData.get('count').minValue;
             colorLegend.maxValue = legendData.get('count').maxValue;
           } else {


### PR DESCRIPTION
In the builder, legendData is always undefined, creating an error when loading heatmap layers.