### PR TITLE
Provide the ArlasColorService globally

### DIFF
--- a/projects/arlas-components/src/lib/services/color.generator.module.ts
+++ b/projects/arlas-components/src/lib/services/color.generator.module.ts
@@ -36,8 +36,7 @@ export class ColorGeneratorModule {
     return {
       ngModule: ColorGeneratorModule,
       providers: [
-        config.loader || {provide: ColorGeneratorLoader, useClass: AwcColorGeneratorLoader},
-        ArlasColorService
+        config.loader || {provide: ColorGeneratorLoader, useClass: AwcColorGeneratorLoader}
       ]
     };
   }
@@ -46,8 +45,7 @@ export class ColorGeneratorModule {
     return {
       ngModule: ColorGeneratorModule,
       providers: [
-        config.loader || {provide: ColorGeneratorLoader, useClass: AwcColorGeneratorLoader},
-        ArlasColorService
+        config.loader || {provide: ColorGeneratorLoader, useClass: AwcColorGeneratorLoader}
       ]
     };
   }

--- a/projects/arlas-components/src/lib/services/color.generator.service.ts
+++ b/projects/arlas-components/src/lib/services/color.generator.service.ts
@@ -21,7 +21,9 @@ import { Injectable } from '@angular/core';
 import { ColorGeneratorLoader } from '../components/componentsUtils';
 import { Subject } from 'rxjs';
 
-@Injectable()
+@Injectable({
+  providedIn: 'root'
+})
 export class ArlasColorService {
 
   private changekeysToColors =  new Subject<void>();


### PR DESCRIPTION
- this is to avoid duplicate instances of the service in case of lazy loading modules
- Fix #755 