### PR TITLE
fix: basemap loading & fullScreen viewer destruction

### DIFF
--- a/projects/arlas-components/src/lib/components/mapgl/basemaps/basemaps.ts
+++ b/projects/arlas-components/src/lib/components/mapgl/basemaps/basemaps.ts
@@ -33,10 +33,9 @@ export class ArlasBasemaps {
     if (!this._selectedStyle) {
       const styles = this.styles();
       const localStorageBasemapStyle: BasemapStyle = JSON.parse(localStorage.getItem(this.LOCAL_STORAGE_BASEMAPS));
-      if (localStorageBasemapStyle && styles.filter(b => b.name === localStorageBasemapStyle.name
-        && 'name' in (b.styleFile as mapboxgl.Style) && 'name' in (localStorageBasemapStyle.styleFile as mapboxgl.Style)
-        && (b.styleFile as mapboxgl.Style)?.name === (localStorageBasemapStyle.styleFile as mapboxgl.Style)?.name).length > 0) {
-        this._selectedStyle = localStorageBasemapStyle;
+      const sameNameBasemaps = localStorageBasemapStyle ? styles.filter(b => b.name === localStorageBasemapStyle.name) : [];
+      if (sameNameBasemaps.length > 0) {
+        this._selectedStyle = sameNameBasemaps[0];
       } else if (!!this.defaultBasemapStyle) {
         this._selectedStyle = this.defaultBasemapStyle;
       } else if (styles && styles.length > 0) {

--- a/projects/arlas-components/src/lib/components/mapgl/mapgl.component.html
+++ b/projects/arlas-components/src/lib/components/mapgl/mapgl.component.html
@@ -33,8 +33,9 @@
   </div>
 </div>
 
-<ng-container *ngIf="displayCurrentCoordinates">
-  <arlas-coordinates [currentLat]="currentLat" [currentLng]="currentLng" (moveToCoordinates$)="moveToCoordinates($event)"></arlas-coordinates>>
+<ng-container>
+  <arlas-coordinates *ngIf="displayCurrentCoordinates" [currentLat]="currentLat"
+    [currentLng]="currentLng" (moveToCoordinates$)="moveToCoordinates($event)"></arlas-coordinates>
 </ng-container>
 <arlas-mapgl-basemap *ngIf="showBasemapsList" [mapSources]="mapSources" [map]="map"
 (mouseleave)="hideBasemapSwitcher()" (basemapChanged)="onChangeBasemapStyle()"></arlas-mapgl-basemap>

--- a/projects/arlas-components/src/lib/components/results/result-detailed-grid/result-detailed-grid.component.html
+++ b/projects/arlas-components/src/lib/components/results/result-detailed-grid/result-detailed-grid.component.html
@@ -2,8 +2,8 @@
   <div class="resultgrid--container">
     <div [hidden]="isDetailedDataShowed">
       <div class="resultgrid__img" [style.height.px]="detailHeight" [style.width.px]="detailWidth">
-        <img class="image_view" #image_detail *ngIf="gridTile.imageEnabled" src="{{imgSrc}}" onerror="this.onerror=null;" (error)="destroyViewer()">
-        <img *ngIf="!gridTile.imageEnabled && !isLoading" src="{{noViewImg}}">
+        <img class="image_view" #image_detail *ngIf="gridTile.imageEnabled" src="{{imgSrc}}" (error)="destroyViewer()">
+        <img *ngIf="(!gridTile.imageEnabled || !imgSrc) && !isLoading" src="{{noViewImg}}">
         <mat-progress-spinner *ngIf="isLoading" [color]="'accent'" [diameter]="detailHeight < detailWidth ? detailHeight / 2 : detailWidth / 2" [mode]="'indeterminate'"></mat-progress-spinner>
       </div>
 

--- a/projects/arlas-components/src/lib/components/results/result-detailed-grid/result-detailed-grid.component.ts
+++ b/projects/arlas-components/src/lib/components/results/result-detailed-grid/result-detailed-grid.component.ts
@@ -123,12 +123,15 @@ export class ResultDetailedGridComponent implements OnChanges, OnDestroy {
   ) { }
 
   public ngOnDestroy(): void {
-    this.destroyViewer();
+    this.destroyViewer(true);
   }
 
   public ngOnChanges(changes: SimpleChanges) {
     if (changes['gridTile']) {
-      this.destroyViewer();
+      if (this.viewer) {
+        this.viewer = this.viewer.destroy();
+      }
+      this.isFullScreen = false;
       this.currentImageIndex = 0;
       this.getImage();
     }
@@ -163,6 +166,7 @@ export class ResultDetailedGridComponent implements OnChanges, OnDestroy {
         });
     } else {
       this.imgSrc = this.gridTile.urlImages[this.currentImageIndex];
+      this.gridTile.imageEnabled = true;
       this.resetViewer();
     }
   }
@@ -182,9 +186,12 @@ export class ResultDetailedGridComponent implements OnChanges, OnDestroy {
     }, 0);
   }
 
-  public destroyViewer(): void {
+  public destroyViewer(isComponentDestroy?: boolean): void {
     if (this.viewer) {
       this.viewer = this.viewer.destroy();
+    }
+    if (isComponentDestroy && this.fullScreenViewer) {
+      this.fullScreenViewer.destroy();
     }
     // Add a delay to allow for the viewer to be destroyed properly
     // before removing it due to visibility rules in the template

--- a/projects/arlas-components/src/lib/components/results/result-detailed-grid/result-detailed-grid.component.ts
+++ b/projects/arlas-components/src/lib/components/results/result-detailed-grid/result-detailed-grid.component.ts
@@ -136,7 +136,7 @@ export class ResultDetailedGridComponent implements OnChanges, OnDestroy {
 
   private getImage() {
     this.imgSrc = undefined;
-    if (!this.gridTile || (this.gridTile && this.gridTile.urlImages.length === 0)) {
+    if (!this.gridTile || (this.gridTile && (!this.gridTile.urlImages || this.gridTile.urlImages.length === 0))) {
       return;
     }
 

--- a/projects/arlas-components/src/lib/components/results/result-list/result-list.component.ts
+++ b/projects/arlas-components/src/lib/components/results/result-list/result-list.component.ts
@@ -928,8 +928,6 @@ export class ResultListComponent implements OnInit, DoCheck, OnChanges, AfterVie
   private onAddItems(itemData: Map<string, ItemDataType>, addOnTop: boolean, index: number) {
     const item = new Item(this.columns, itemData);
     item.identifier = <string>itemData.get(this.fieldsConfiguration.idFieldName);
-    item.imageEnabled = true;
-    item.thumbnailEnabled = true;
     if (this.fieldsConfiguration.titleFieldNames) {
       item.title = this.fieldsConfiguration.titleFieldNames
         .map(field => <string>itemData.get(field.fieldPath + '_title'))
@@ -962,7 +960,7 @@ export class ResultListComponent implements OnInit, DoCheck, OnChanges, AfterVie
         item.iconCssClass = item.iconCssClass.trim();
       }
     }
-    item.imageEnabled = true; // itemData.get('imageEnabled') === 'true';
+    item.imageEnabled = itemData.get('imageEnabled') === 'true';
     item.thumbnailEnabled = itemData.get('thumbnailEnabled') === 'true';
 
     /** Retro-compatibility code */
@@ -994,15 +992,7 @@ export class ResultListComponent implements OnInit, DoCheck, OnChanges, AfterVie
       });
     }
     if (item.thumbnailEnabled && this.fieldsConfiguration.urlThumbnailTemplate) {
-      item.urlThumbnail = this.fieldsConfiguration.urlThumbnailTemplate;
-      /** match : => ["{field1}", "{field2}"] */
-      const matches = this.fieldsConfiguration.urlThumbnailTemplate.match(/{(.+?)}/g);
-      if (matches) {
-        matches.forEach(t => {
-          const key: string = t.replace('{', '').replace('}', '');
-          item.urlThumbnail = item.urlThumbnail.replace(t, itemData.get(key).toString());
-        });
-      }
+      item.urlThumbnail = matchAndReplace(itemData, this.fieldsConfiguration.urlThumbnailTemplate);
     }
 
     item.position = this.items.length + 1;

--- a/projects/arlas-components/src/lib/components/results/utils/results.utils.ts
+++ b/projects/arlas-components/src/lib/components/results/utils/results.utils.ts
@@ -113,7 +113,9 @@ export function matchAndReplace(data: Map<string, ItemDataType>, template: strin
   let replaced = template;
   template.match(/{(.+?)}/g)?.forEach(t => {
     const key: string = t.replace('{', '').replace('}', '');
-    replaced = replaced.replace(t, data.get(key).toString());
+    if (!!data.get(key)) {
+      replaced = replaced.replace(t, data.get(key).toString());
+    }
   });
   return replaced;
 }


### PR DESCRIPTION
Basemap loading: there was an issue with how the basemap was loaded from the local storage, as it was expected for it to be stored with the already fetched styleFile, and that it could be stored as just a URL.

Fullscreen viewer: when clicking on a grid tile as soon as it loads, since the list fetches data multiple time at the beginning of the app, the component was destroyed but the full screen viewer was not, and the arrows and description were put onto the first fullscreen viewer created