### PR TITLE
fix: add min-height to avoid useless scroll.

### DIFF
--- a/projects/arlas-components/src/lib/components/powerbars/powerbars.component.css
+++ b/projects/arlas-components/src/lib/components/powerbars/powerbars.component.css
@@ -84,8 +84,8 @@
 }
 
 .powerbar-list-scrollable {
-  min-height: 35px;
   overflow-y: auto;
   overflow-x: clip;
   padding-right: 10px;
+  padding-bottom: 10px;
 }

--- a/projects/arlas-components/src/lib/components/powerbars/powerbars.component.css
+++ b/projects/arlas-components/src/lib/components/powerbars/powerbars.component.css
@@ -84,6 +84,7 @@
 }
 
 .powerbar-list-scrollable {
+  min-height: 35px;
   overflow-y: auto;
   overflow-x: clip;
   padding-right: 10px;


### PR DESCRIPTION
fix gisaia/ARLAS-wui#731

with one
![image](https://github.com/gisaia/ARLAS-web-components/assets/155989195/3ea47077-e8b2-4a85-8b64-238e4d3b95e4)

full list
![image](https://github.com/gisaia/ARLAS-web-components/assets/155989195/35f00280-1c8e-40f2-b81a-1cf749b3a9c9)
