### PR TITLE
Use grid_view icon

### DIFF
--- a/projects/arlas-components/src/lib/components/results/result-list/result-list.component.html
+++ b/projects/arlas-components/src/lib/components/results/result-list/result-list.component.html
@@ -78,7 +78,7 @@
                 <mat-icon>list</mat-icon>
               </mat-button-toggle>
               <mat-button-toggle id="grid_mode_btn" matTooltip="{{GRID_MODE | translate}}" value="{{ModeEnum.grid}}" [checked]="resultMode==ModeEnum.grid">
-                <mat-icon>apps</mat-icon>
+                <mat-icon>grid_view</mat-icon>
               </mat-button-toggle>
             </mat-button-toggle-group>
           </div>


### PR DESCRIPTION
Using : 

![image](https://github.com/gisaia/ARLAS-web-components/assets/26741864/2081e342-f309-4f0e-9bba-305eb4387e7e)

To distinguish it from the app switcher icon