### PR TITLE
fix: avoid overlapping outline when text overflows on multiple lines

### DIFF
--- a/projects/arlas-components/src/lib/components/results/result-item/result-item.component.css
+++ b/projects/arlas-components/src/lib/components/results/result-item/result-item.component.css
@@ -53,14 +53,15 @@
 }
 
 .resultitem__cell--label__filled {
-  padding: 3px;
+  padding: 2px;
   border-radius:2px;
 }
 
 .resultitem__cell--label__outlined {
-  padding: 3px;
+  padding: 2px;
   border-radius:2px;
   border : 1.5px solid;
+  display: inline-grid;
 }
 
 .resultdetaileditem__actions {


### PR DESCRIPTION
- Fix gisaia/ARLAS-wui#852
 
![image](https://github.com/user-attachments/assets/747900b5-aaa8-4b76-a09d-79751d252a1a)
