### PR TITLE
Rename to mapbox and remove uneeded methods

### DIFF
--- a/projects/arlas-components/src/lib/components/mapgl-basemap/mapgl-basemap.component.ts
+++ b/projects/arlas-components/src/lib/components/mapgl-basemap/mapgl-basemap.component.ts
@@ -25,7 +25,7 @@ import { MapglService } from '../../services/mapgl.service';
 import { MapboxBasemapService } from '../mapgl/basemaps/basemap.service';
 import { BasemapStyle } from '../mapgl/basemaps/basemap.config';
 import { ArlasBasemaps } from '../mapgl/basemaps/basemaps';
-import { ArlasMapGL } from '../mapgl/model/ArlasMapGL';
+import { ArlasMapboxGL } from '../mapgl/model/ArlasMapboxGL';
 
 @Component({
   selector: 'arlas-mapgl-basemap',
@@ -35,7 +35,7 @@ import { ArlasMapGL } from '../mapgl/model/ArlasMapGL';
 export class MapglBasemapComponent implements OnInit {
   private LOCAL_STORAGE_BASEMAPS = 'arlas_last_base_map';
 
-  @Input() public map: ArlasMapGL;
+  @Input() public map: ArlasMapboxGL;
   @Input() public mapSources: Array<MapSource>;
 
   @Output() public basemapChanged = new EventEmitter<void>();

--- a/projects/arlas-components/src/lib/components/mapgl/basemaps/basemap.service.ts
+++ b/projects/arlas-components/src/lib/components/mapgl/basemaps/basemap.service.ts
@@ -25,7 +25,7 @@ import { BasemapStyle } from './basemap.config';
 import mapboxgl from 'mapbox-gl';
 import { Observable, Subject, catchError, forkJoin, of, tap } from 'rxjs';
 import { HttpClient } from '@angular/common/http';
-import { ArlasMapGL } from '../model/ArlasMapGL';
+import { ArlasMapboxGL } from '../model/ArlasMapboxGL';
 
 @Injectable({
   providedIn: 'root'
@@ -43,7 +43,7 @@ export class MapboxBasemapService {
     this.basemaps = basemaps;
   }
 
-  public addProtomapBasemap(map: ArlasMapGL) {
+  public addProtomapBasemap(map: ArlasMapboxGL) {
     const selectedBasemap = this.basemaps.getSelected();
     if (selectedBasemap.type === 'protomap') {
       const styleFile = selectedBasemap.styleFile as mapboxgl.Style;
@@ -69,7 +69,7 @@ export class MapboxBasemapService {
     this.protomapBasemapAddedSource.next(true);
   }
 
-  public removeProtomapBasemap(map: ArlasMapGL) {
+  public removeProtomapBasemap(map: ArlasMapboxGL) {
     const selectedBasemap = this.basemaps.getSelected();
     if (selectedBasemap.type === 'protomap') {
       (selectedBasemap.styleFile as mapboxgl.Style).layers.forEach(l => {
@@ -81,7 +81,7 @@ export class MapboxBasemapService {
     }
   }
 
-  public declareProtomapProtocol(map: ArlasMapGL) {
+  public declareProtomapProtocol(map: ArlasMapboxGL) {
     const protocol = new pmtiles.Protocol();
     if (!(mapboxgl as any).Style.getSourceType('pmtiles-type')) {
       /** addSourceType is private */

--- a/projects/arlas-components/src/lib/components/mapgl/mapgl.component.ts
+++ b/projects/arlas-components/src/lib/components/mapgl/mapgl.component.ts
@@ -71,7 +71,7 @@ import {
   OnMoveResult,
   VisualisationSetConfig
 } from './model/AbstractArlasMapGL';
-import { ArlasMapGL, ArlasMapGlConfig } from './model/ArlasMapGL';
+import { ArlasMapboxGL, ArlasMapGlConfig } from './model/ArlasMapboxGL';
 import { ArlasDraw } from './model/ArlasDraw';
 import { Geometry } from '@turf/helpers/dist/js/lib/geojson';
 
@@ -97,7 +97,7 @@ export const LAYER_SWITCHER_TOOLTIP = marker('Manage layers');
 })
 export class MapglComponent implements OnInit, AfterViewInit, OnChanges, OnDestroy {
 
-  public map: ArlasMapGL;
+  public map: ArlasMapboxGL;
   public draw: ArlasDraw;
   public zoom: number;
   public legendOpen = true;
@@ -746,7 +746,7 @@ export class MapglComponent implements OnInit, AfterViewInit, OnChanges, OnDestr
       }
     };
     console.log('declare');
-    this.map = new ArlasMapGL(config);
+    this.map = new ArlasMapboxGL(config);
     console.log(this.map);
 
     fromEvent(window, 'beforeunload').subscribe(() => {

--- a/projects/arlas-components/src/lib/components/mapgl/model/AbstractArlasMapGL.ts
+++ b/projects/arlas-components/src/lib/components/mapgl/model/AbstractArlasMapGL.ts
@@ -24,8 +24,8 @@ import { ControlButton } from '../mapgl.component.control';
 import { ARLAS_ID, ExternalEvent, FILLSTROKE_LAYER_PREFIX, MapLayers, SCROLLABLE_ARLAS_ID } from './mapLayers';
 import { Observable, Subscription } from 'rxjs';
 import { ElementIdentifier } from '../../results/utils/results.utils';
-import { CdkDragDrop, moveItemInArray } from '@angular/cdk/drag-drop';
-import { AnyLayer } from "mapbox-gl";
+
+import { MapOverride } from './map.type';
 
 export type ControlPosition = 'top-right' | 'top-left' | 'bottom-right' | 'bottom-left';
 
@@ -128,7 +128,7 @@ export interface VisualisationSetConfig {
   enabled?: boolean;
 }
 
-export abstract class AbstractArlasMapGL {
+export abstract class AbstractArlasMapGL implements MapOverride {
   /**
    *  props and method with unknow type will be specific to the map provider
    *  we used.
@@ -215,6 +215,130 @@ export abstract class AbstractArlasMapGL {
     this._dataSources=  config.dataSources;
 
     this.init(config);
+  }
+  setMinZoom(minZoom?: number): this {
+    throw new Error('Method not implemented.');
+  }
+  setMaxZoom(maxZoom?: number): this {
+    throw new Error('Method not implemented.');
+  }
+  project(lnglat: unknown): unknown {
+    throw new Error('Method not implemented.');
+  }
+  unproject(point: unknown): unknown {
+    throw new Error('Method not implemented.');
+  }
+  queryRenderedFeatures(pointOrBox?: unknown, options?: { layers?: string[]; filter?: any[]; }): unknown[] {
+    throw new Error('Method not implemented.');
+  }
+  setStyle(style: unknown, options?: { diff?: boolean; localIdeographFontFamily?: string; }): this {
+    throw new Error('Method not implemented.');
+  }
+  getStyle(): unknown {
+    throw new Error('Method not implemented.');
+  }
+  addSource(id: string, source: unknown): this {
+    throw new Error('Method not implemented.');
+  }
+  removeSource(id: string): this {
+    throw new Error('Method not implemented.');
+  }
+  getSource(id: string): unknown {
+    throw new Error('Method not implemented.');
+  }
+  addImage(name: string, image: HTMLImageElement | ArrayBufferView | ImageData | ImageBitmap | { width: number; height: number; data: Uint8Array | Uint8ClampedArray; }, options?: { pixelRatio?: number; sdf?: boolean; }): this {
+    throw new Error('Method not implemented.');
+  }
+  loadImage(url: string, callback: Function): this {
+    throw new Error('Method not implemented.');
+  }
+  addLayer(layer: unknown, before?: string): this {
+    throw new Error('Method not implemented.');
+  }
+  moveLayer(id: string, beforeId?: string): this {
+    throw new Error('Method not implemented.');
+  }
+  removeLayer(id: string): this {
+    throw new Error('Method not implemented.');
+  }
+  getLayer(id: string): unknown {
+    throw new Error('Method not implemented.');
+  }
+  setFilter(layer: string, filter?: boolean | any[], options?: unknown): this {
+    throw new Error('Method not implemented.');
+  }
+  getLight(): unknown {
+    throw new Error('Method not implemented.');
+  }
+  setFeatureState(feature: unknown, state: { [key: string]: any; }): void {
+    throw new Error('Method not implemented.');
+  }
+  getFeatureState(feature: unknown): { [key: string]: any; } {
+    throw new Error('Method not implemented.');
+  }
+  removeFeatureState(target: unknown, key?: string): void {
+    throw new Error('Method not implemented.');
+  }
+  getContainer(): HTMLElement {
+    throw new Error('Method not implemented.');
+  }
+  getCanvasContainer(): HTMLElement {
+    throw new Error('Method not implemented.');
+  }
+  getCanvas(): HTMLCanvasElement {
+    throw new Error('Method not implemented.');
+  }
+  getCenter(): unknown {
+    throw new Error('Method not implemented.');
+  }
+  setCenter(center: unknown, unknown?: unknown): this {
+    throw new Error('Method not implemented.');
+  }
+  panTo(lnglat: unknown, options?: unknown, unknown?: unknown): this {
+    throw new Error('Method not implemented.');
+  }
+  getZoom(): number {
+    throw new Error('Method not implemented.');
+  }
+  setZoom(zoom: number, unknown?: unknown): this {
+    throw new Error('Method not implemented.');
+  }
+  getBearing(): number {
+    throw new Error('Method not implemented.');
+  }
+  setBearing(bearing: number, unknown?: unknown): this {
+    throw new Error('Method not implemented.');
+  }
+  rotateTo(bearing: number, options?: unknown, unknown?: unknown): this {
+    throw new Error('Method not implemented.');
+  }
+  setPitch(pitch: number, unknown?: unknown): this {
+    throw new Error('Method not implemented.');
+  }
+  cameraForBounds(bounds: unknown, options?: unknown): unknown {
+    throw new Error('Method not implemented.');
+  }
+  fitBounds(bounds: unknown, options?: unknown, unknown?: unknown): this {
+    throw new Error('Method not implemented.');
+  }
+
+  easeTo(options: unknown, unknown?: unknown): this {
+    throw new Error('Method not implemented.');
+  }
+  flyTo(options: unknown, unknown?: unknown): this {
+    throw new Error('Method not implemented.');
+  }
+  on<T extends never>(type: T, layer: string, listener: (ev: unknown) => void): this;
+  on<T extends never>(type: T, listener: (ev: unknown) => void): this;
+  on(type: string, listener: (ev: any) => void): this;
+  on(type: unknown, layer: unknown, listener?: unknown): this {
+    throw new Error('Method not implemented.');
+  }
+  once<T extends never>(type: T, layer: string, listener: (ev: unknown) => void): this;
+  once<T extends never>(type: T, listener: (ev: unknown) => void): this;
+  once(type: string, listener: (ev: any) => void): this;
+  once(type: unknown, layer: unknown, listener?: unknown): this {
+    throw new Error('Method not implemented.');
   }
 
   protected init(config: BaseMapGlConfig<any>): void {
@@ -447,9 +571,14 @@ export abstract class AbstractArlasMapGL {
   }
 
   public enableLayoutVisibility(layer: string){
-    this.getMapProvider().setLayoutProperty(layer, 'visibility', 'visible');
+    this.setLayoutProperty(layer, 'visibility', 'visible');
     this.setStrokeLayoutVisibility(layer, 'visible');
     this.setScrollableLayoutVisibility(layer, 'visible');
+  }
+
+  public setLayoutProperty(layer: string, name: string, value: any, options?: any){
+    this.getMapProvider().setLayoutProperty(layer, name, value, options);
+    return this;
   }
 
   public findVisualisationSetLayer(visuName: string){
@@ -466,5 +595,24 @@ export abstract class AbstractArlasMapGL {
     this._eventSubscription.forEach(s => s.unsubscribe());
   }
 
+  public getBounds(){
+    return this.getMapProvider().getBounds();
+  }
+
+  public abstract resize(eventData?: unknown): this;
+  public abstract getMaxBounds(): unknown;
+  public abstract setMaxBounds(unknown?: unknown): this;
+  public getMaxZoom(): number {
+    return this.getMapProvider().getMaxZoom();
+  }
+
+  public getMinZoom(): number {
+    return this.getMapProvider().getMinZoom();
+  }
+
+  public getPitch(): number {
+    return  this.getMapProvider().getPitch() ;
+  }
+  
 }
 

--- a/projects/arlas-components/src/lib/components/mapgl/model/ArlasMapboxGL.ts
+++ b/projects/arlas-components/src/lib/components/mapgl/model/ArlasMapboxGL.ts
@@ -45,7 +45,6 @@ import { ControlButton, PitchToggle } from '../mapgl.component.control';
 import { ARLAS_ID, ExternalEvent, FILLSTROKE_LAYER_PREFIX, MapLayers, SCROLLABLE_ARLAS_ID } from './mapLayers';
 import { fromEvent, map } from 'rxjs';
 import { debounceTime } from 'rxjs/operators';
-import { ElementIdentifier } from '../../results/utils/results.utils';
 import { MapOverride } from './map.type';
 
 export interface ArlasMapGlConfig extends BaseMapGlConfig<MapboxOptions>  {
@@ -74,7 +73,7 @@ export interface ArlasMapGlConfig extends BaseMapGlConfig<MapboxOptions>  {
  *  - wrap of provider methode could be implemented in another class in middle of
  *  abstract class.
  */
-export class ArlasMapGL extends AbstractArlasMapGL implements MapOverride {
+export class ArlasMapboxGL extends AbstractArlasMapGL implements MapOverride {
   protected _mapLayers: MapLayers<AnyLayer>;
   protected _mapProvider: mapboxgl.Map;
   // Lat/lng on mousedown (start); mouseup (end) and mousemove (between start and end)
@@ -110,7 +109,7 @@ export class ArlasMapGL extends AbstractArlasMapGL implements MapOverride {
       this.getMapProvider().showTileBoundaries = false;
       this._bindCustomEvent();
       // Fit bounds on current bounds to emit init position in moveend bus
-      this.getMapProvider().fitBounds(this.getMapProvider().getBounds());
+      this.getMapProvider().fitBounds(this.getBounds());
       this._initVisualisationSet();
     });
   }
@@ -227,14 +226,14 @@ export class ArlasMapGL extends AbstractArlasMapGL implements MapOverride {
   }
 
   protected _loadInternalImage(filePath: string, name: string, errorMessage?: string, opt?: any){
-    this.getMapProvider().loadImage(filePath, (error, image) => {
+    this.loadImage(filePath, (error, image) => {
       if (error) {
         console.warn(errorMessage);
       } else {
         if(opt){
-          this.getMapProvider().addImage(name, image, opt);
+          this.addImage(name, image, opt);
         } else {
-          this.getMapProvider().addImage(name, image);
+          this.addImage(name, image);
         }
       }
     });
@@ -323,7 +322,7 @@ export class ArlasMapGL extends AbstractArlasMapGL implements MapOverride {
       this.visualisationsSets.status.forEach((b, vs) => {
         if (!b) {
           this.visualisationsSets.visualisations.get(vs).forEach(l => {
-            this.getMapProvider().setLayoutProperty(l, 'visibility', 'none');
+            this.setLayoutProperty(l, 'visibility', 'none');
             this.setStrokeLayoutVisibility(l, 'none');
             this.setScrollableLayoutVisibility(l, 'none');
           });
@@ -332,7 +331,7 @@ export class ArlasMapGL extends AbstractArlasMapGL implements MapOverride {
       this.visualisationsSets.status.forEach((b, vs) => {
         if (b) {
           this.visualisationsSets.visualisations.get(vs).forEach(l => {
-            this.getMapProvider().setLayoutProperty(l, 'visibility', 'visible');
+            this.setLayoutProperty(l, 'visibility', 'visible');
             this.setStrokeLayoutVisibility(l, 'visible');
             this.setScrollableLayoutVisibility(l, 'visible');
           });
@@ -353,46 +352,46 @@ export class ArlasMapGL extends AbstractArlasMapGL implements MapOverride {
           const layer = this.layersMap.get(l);
           const scrollableId = layer.id.replace(ARLAS_ID, SCROLLABLE_ARLAS_ID);
           const scrollableLayer = this.layersMap.get(scrollableId);
-          if (!!scrollableLayer && !!this.getMapProvider().getLayer(scrollableId)) {
-            this.getMapProvider().moveLayer(scrollableId);
+          if (!!scrollableLayer && !!this.getLayer(scrollableId)) {
+            this.moveLayer(scrollableId);
           }
-          if (!!this.getMapProvider().getLayer(l)) {
-            this.getMapProvider().moveLayer(l);
+          if (!!this.getLayer(l)) {
+            this.moveLayer(l);
             if (layer.type === 'fill') {
               const strokeId = layer.id.replace(ARLAS_ID, FILLSTROKE_LAYER_PREFIX);
               const strokeLayer = this.layersMap.get(strokeId);
-              if (!!strokeLayer && !!this.getMapProvider().getLayer(strokeId)) {
-                this.getMapProvider().moveLayer(strokeId);
+              if (!!strokeLayer && !!this.getLayer(strokeId)) {
+                this.moveLayer(strokeId);
               }
               if (!!strokeLayer && !!strokeLayer.id) {
                 const selectId = 'arlas-' + ExternalEvent.select.toString() + '-' + strokeLayer.id;
                 const selectLayer = this.layersMap.get(selectId);
-                if (!!selectLayer && !!this.getMapProvider().getLayer(selectId)) {
-                  this.getMapProvider().moveLayer(selectId);
+                if (!!selectLayer && !!this.getLayer(selectId)) {
+                  this.moveLayer(selectId);
                 }
                 const hoverId = 'arlas-' + ExternalEvent.hover.toString() + '-' + strokeLayer.id;
                 const hoverLayer = this.layersMap.get(hoverId);
-                if (!!hoverLayer && !!this.getMapProvider().getLayer(hoverId)) {
-                  this.getMapProvider().moveLayer(hoverId);
+                if (!!hoverLayer && !!this.getLayer(hoverId)) {
+                  this.moveLayer(hoverId);
                 }
               }
             }
           }
           const selectId = 'arlas-' + ExternalEvent.select.toString() + '-' + layer.id;
           const selectLayer = this.layersMap.get(selectId);
-          if (!!selectLayer && !!this.getMapProvider().getLayer(selectId)) {
-            this.getMapProvider().moveLayer(selectId);
+          if (!!selectLayer && !!this.getLayer(selectId)) {
+            this.moveLayer(selectId);
           }
           const hoverId = 'arlas-' + ExternalEvent.hover.toString() + '-' + layer.id;
           const hoverLayer = this.layersMap.get(hoverId);
-          if (!!hoverLayer && !!this.getMapProvider().getLayer(hoverId)) {
-            this.getMapProvider().moveLayer(hoverId);
+          if (!!hoverLayer && !!this.getLayer(hoverId)) {
+            this.moveLayer(hoverId);
           }
         }
       }
     }
 
-    this.getColdOrHotLayers().forEach(id => this.getMapProvider().moveLayer(id));
+    this.getColdOrHotLayers().forEach(id => this.moveLayer(id));
   }
 
   public setLayersMap(mapLayers: MapLayers<AnyLayer>, layers?: Array<AnyLayer>){
@@ -409,7 +408,7 @@ export class ArlasMapGL extends AbstractArlasMapGL implements MapOverride {
 
 
   public getMapExtend(): MapExtend {
-    const bounds = this.getMapProvider().getBounds();
+    const bounds = this.getBounds();
     return  { bounds: bounds.toArray(), center: bounds.getCenter().toArray(), zoom: this.getMapProvider().getZoom() };
   }
 
@@ -450,7 +449,7 @@ export class ArlasMapGL extends AbstractArlasMapGL implements MapOverride {
                                 collection?: string): void {
     if (this._mapLayers && this._mapLayers.externalEventLayers) {
       this._mapLayers.externalEventLayers.filter(layer => layer.on === visibilityEvent).forEach(layer => {
-        if (this.getMapProvider().getLayer(layer.id) !== undefined) {
+        if (this.getLayer(layer.id) !== undefined) {
           let originalLayerIsVisible = false;
           const fullLayer = this.layersMap.get(layer.id);
           const isCollectionCompatible = (!collection || (!!collection && (fullLayer.source as string).includes(collection)));
@@ -472,11 +471,11 @@ export class ArlasMapGL extends AbstractArlasMapGL implements MapOverride {
             }
             if (visibilityCondition && originalLayerIsVisible) {
               layerFilter.push(visibilityFilter);
-              this.getMapProvider().setFilter(layer.id, layerFilter);
-              this.getMapProvider().setLayoutProperty(layer.id, 'visibility', 'visible');
+              this.setFilter(layer.id, layerFilter);
+              this.setLayoutProperty(layer.id, 'visibility', 'visible');
             } else {
-              this.getMapProvider().setFilter(layer.id, (layer as any).filter);
-              this.getMapProvider().setLayoutProperty(layer.id, 'visibility', 'none');
+              this.setFilter(layer.id, (layer as any).filter);
+              this.setLayoutProperty(layer.id, 'visibility', 'none');
             }
           }
         }
@@ -507,7 +506,7 @@ export class ArlasMapGL extends AbstractArlasMapGL implements MapOverride {
     this.visualisationsSets.visualisations.set(visualisation.name, new Set(visualisation.layers));
     this.visualisationsSets.status.set(visualisation.name, visualisation.enabled);
     layers.forEach(layer => {
-      this.getMapProvider().addLayer(layer);
+      this.addLayer(layer);
     });
 
     this.setLayersMap(this._mapLayers as MapLayers<AnyLayer>, layers);
@@ -715,21 +714,21 @@ export class ArlasMapGL extends AbstractArlasMapGL implements MapOverride {
   }
 
   public getWestBounds(){
-    return this.getMapProvider().getBounds().getWest();
+    return this.getBounds().getWest();
   }
   public getNorthBounds(){
-    return this.getMapProvider().getBounds().getNorth();
+    return this.getBounds().getNorth();
   }
 
   public getNorthEastBounds(){
-    return this.getMapProvider().getBounds().getNorthEast();
+    return this.getBounds().getNorthEast();
   }
   public getSouthBounds(){
-    return this.getMapProvider().getBounds().getSouth();
+    return this.getBounds().getSouth();
   }
 
   public getSouthWestBounds(){
-    return this.getMapProvider().getBounds().getSouthWest();
+    return this.getBounds().getSouthWest();
   }
   public getEstBounds(){
     return this._mapProvider.getBounds().getEast();
@@ -740,8 +739,8 @@ export class ArlasMapGL extends AbstractArlasMapGL implements MapOverride {
    *******/
 
 
-  public addLayer(layerId: AnyLayer, before?: string){
-    this._mapProvider.addLayer(layerId, before);
+  public addLayer(layer: AnyLayer, before?: string){
+    this._mapProvider.addLayer(layer, before);
     return this;
   }
 
@@ -752,15 +751,6 @@ export class ArlasMapGL extends AbstractArlasMapGL implements MapOverride {
 
   public getSource(id: string){
     return this._mapProvider.getSource(id);
-  }
-
-  public setLayoutProperty(layer: string, name: string, value: any, options?: FilterOptions){
-    this._mapProvider.setLayoutProperty(layer, name, value, options);
-    return this;
-  }
-
-  public getBounds(){
-    return this._mapProvider.getBounds();
   }
 
   public fitBounds(bounds: LngLatBoundsLike, options?: mapboxgl.FitBoundsOptions, eventData?: mapboxgl.EventData){
@@ -830,10 +820,6 @@ export class ArlasMapGL extends AbstractArlasMapGL implements MapOverride {
     return this;
   }
 
-  public areTilesLoaded(): boolean {
-    return this._mapProvider.areTilesLoaded();
-  }
-
   public cameraForBounds(bounds: mapboxgl.LngLatBoundsLike,
                          options?: mapboxgl.CameraForBoundsOptions): mapboxgl.CameraForBoundsResult | undefined {
     return this._mapProvider.cameraForBounds(bounds, options);
@@ -844,14 +830,6 @@ export class ArlasMapGL extends AbstractArlasMapGL implements MapOverride {
     return this;
   }
 
-  public fitScreenCoordinates(p0: mapboxgl.PointLike,
-                              p1: mapboxgl.PointLike,
-                              bearing: number,
-                              options?: mapboxgl.AnimationOptions & mapboxgl.CameraOptions,
-                              eventData?: mapboxgl.EventData): this {
-    this._mapProvider.fitScreenCoordinates(p0, p1, bearing, options);
-    return this;
-  }
 
   public getBearing(): number {
     return this._mapProvider.getBearing();
@@ -869,14 +847,6 @@ export class ArlasMapGL extends AbstractArlasMapGL implements MapOverride {
     return this._mapProvider.getFeatureState(feature);
   }
 
-  public getFilter(layer: string): any[] {
-    return this._mapProvider.getFilter(layer);
-  }
-
-  public getLayoutProperty(layer: string, name: string): any {
-    return this._mapProvider.getLayoutProperty(layer, name);
-  }
-
   public getLight(): mapboxgl.Light {
     return this._mapProvider.getLight();
   }
@@ -885,97 +855,10 @@ export class ArlasMapGL extends AbstractArlasMapGL implements MapOverride {
     return this._mapProvider.getMaxBounds();
   }
 
-  public getMaxPitch(): number {
-    return this._mapProvider.getMaxPitch();
-  }
-
-  public getMaxZoom(): number {
-    return this._mapProvider.getMaxZoom();
-  }
-
-  public getMinPitch(): number {
-    return  this._mapProvider.getMinPitch();
-  }
-
-  public getMinZoom(): number {
-    return this._mapProvider.getMinZoom();
-  }
-
-  public getPadding(): mapboxgl.PaddingOptions {
-    return this._mapProvider.getPadding();
-  }
-
-  public getPaintProperty(layer: string, name: string): any {
-    return  this._mapProvider.getPaintProperty(layer, name) ;
-  }
-
-  public getPitch(): number {
-    return  this._mapProvider.getPitch() ;
-  }
+  
 
   public getRenderWorldCopies(): boolean {
     return  this._mapProvider.getRenderWorldCopies() ;
-  }
-
-  public hasControl(control: mapboxgl.IControl): boolean {
-    return  this._mapProvider.hasControl(control) ;
-  }
-
-  public hasImage(name: string): boolean {
-    return this._mapProvider.hasImage(name);
-  }
-
-  public isEasing(): boolean {
-    return this._mapProvider.isEasing();
-  }
-
-  public isMoving(): boolean {
-    return this._mapProvider.isMoving();
-  }
-
-  public isRotating(): boolean {
-    return this._mapProvider.isRotating();
-  }
-
-  public isSourceLoaded(id: string): boolean {
-    return this._mapProvider.isSourceLoaded(id);
-  }
-
-  public isStyleLoaded(): boolean {
-    return this._mapProvider.isStyleLoaded();
-  }
-
-  public isZooming(): boolean {
-    return this._mapProvider.isZooming();
-  }
-
-  public jumpTo(options: mapboxgl.CameraOptions, eventData?: mapboxgl.EventData): this {
-    this._mapProvider.jumpTo(options, eventData);
-    return this;
-  }
-
-  public listImages(): string[] {
-    return this._mapProvider.listImages();
-  }
-
-  public loaded(): boolean {
-    return this._mapProvider.loaded();
-  }
-
-  public off<T extends keyof mapboxgl.MapLayerEventType>(
-    type: T,
-    layer: string,
-    listener: (ev: (mapboxgl.MapLayerEventType[T] & mapboxgl.EventData)) => void): this;
-  public off<T extends keyof mapboxgl.MapEventType>(type: T, listener: (ev: (mapboxgl.MapEventType[T] & mapboxgl.EventData)) => void): this;
-  public off(type: string, listener: (ev: any) => void): this;
-  public off(type, layer, listener?): this {
-    this._mapProvider.off(type, layer, listener);
-    return this;
-  }
-
-  public panBy(offset: mapboxgl.PointLike, options?: mapboxgl.AnimationOptions, eventData?: mapboxgl.EventData): this {
-    this._mapProvider.panBy(offset, options, eventData);
-    return this;
   }
 
   public panTo(lnglat: mapboxgl.LngLatLike, options?: mapboxgl.AnimationOptions, eventdata?: mapboxgl.EventData): this {
@@ -983,39 +866,8 @@ export class ArlasMapGL extends AbstractArlasMapGL implements MapOverride {
     return this;
   }
 
-  public querySourceFeatures(sourceID: string, parameters?: {
-    sourceLayer?: string | undefined;
-    filter?: any[] | undefined;
-  } & mapboxgl.FilterOptions): mapboxgl.MapboxGeoJSONFeature[] {
-    return this._mapProvider.querySourceFeatures(sourceID, parameters);
-  }
-
-  public remove(): void {
-    this._mapProvider.remove();
-  }
-
-  public removeControl(control: mapboxgl.Control | mapboxgl.IControl): this {
-    this._mapProvider.removeControl(control);
-    return this;
-  }
-
   public removeFeatureState(target: mapboxgl.FeatureIdentifier | mapboxgl.MapboxGeoJSONFeature, key?: string): void {
     this._mapProvider.removeFeatureState(target, key);
-  }
-
-  public removeImage(name: string): this {
-    this._mapProvider.removeImage(name);
-    return this;
-  }
-
-  public resetNorth(options?: mapboxgl.AnimationOptions, eventData?: mapboxgl.EventData): this {
-    this._mapProvider.resetNorth(options, eventData);
-    return this;
-  }
-
-  public resetNorthPitch(options?: mapboxgl.AnimationOptions | null, eventData?: mapboxgl.EventData | null): this {
-    this._mapProvider.resetNorthPitch(options, eventData);
-    return this;
   }
 
   public resize(eventData?: mapboxgl.EventData): this {
@@ -1044,23 +896,8 @@ export class ArlasMapGL extends AbstractArlasMapGL implements MapOverride {
     return this;
   }
 
-  public setLayerZoomRange(layerId: string, minzoom: number, maxzoom: number): this {
-    this._mapProvider.setLayerZoomRange(layerId, minzoom, maxzoom);
-    return this;
-  }
-
-  public setLight(light: mapboxgl.Light, options?: mapboxgl.FilterOptions): this {
-    this._mapProvider.setLight(light, options);
-    return this;
-  }
-
   public setMaxBounds(lnglatbounds?: mapboxgl.LngLatBoundsLike): this {
     this._mapProvider.setMaxBounds(lnglatbounds);
-    return this;
-  }
-
-  public setMaxPitch(maxPitch?: number | null): this {
-    this._mapProvider.setMaxPitch(maxPitch);
     return this;
   }
 
@@ -1069,23 +906,8 @@ export class ArlasMapGL extends AbstractArlasMapGL implements MapOverride {
     return this;
   }
 
-  public setMinPitch(minPitch?: number | null): this {
-    this._mapProvider.setMinPitch(minPitch);
-    return this;
-  }
-
   public setMinZoom(minZoom?: number | null): this {
     this._mapProvider.setMinZoom(minZoom);
-    return this;
-  }
-
-  public setPadding(padding: mapboxgl.PaddingOptions, eventData?: mapboxgl.EventData): this {
-    this._mapProvider.setPadding(padding, eventData);
-    return this;
-  }
-
-  public setPaintProperty(layer: string, name: string, value: any, options?: mapboxgl.FilterOptions): this {
-    this._mapProvider.setPaintProperty(layer, name, value, options);
     return this;
   }
 
@@ -1094,45 +916,8 @@ export class ArlasMapGL extends AbstractArlasMapGL implements MapOverride {
     return this;
   }
 
-  public setRenderWorldCopies(renderWorldCopies?: boolean): this {
-    this._mapProvider.setRenderWorldCopies(renderWorldCopies);
-    return this;
-  }
-
   public setZoom(zoom: number, eventData?: mapboxgl.EventData): this {
     this._mapProvider.setZoom(zoom, eventData);
-    return this;
-  }
-
-  public snapToNorth(options?: mapboxgl.AnimationOptions, eventData?: mapboxgl.EventData): this {
-    this._mapProvider.snapToNorth(options, eventData);
-    return this;
-  }
-
-  public stop(): this {
-    this._mapProvider.stop();
-    return this;
-  }
-
-  public triggerRepaint(): void {
-    this._mapProvider.triggerRepaint();
-  }
-
-  public zoomIn(options?: mapboxgl.AnimationOptions, eventData?: mapboxgl.EventData): this {
-    this._mapProvider.zoomIn(options, eventData);
-    return this;
-  }
-
-  public zoomOut(options?: mapboxgl.AnimationOptions, eventData?: mapboxgl.EventData): this {
-    this._mapProvider.zoomOut(options, eventData);
-    return undefined;
-  }
-
-  public zoomTo(
-    zoom: number,
-                options?: mapboxgl.AnimationOptions,
-    eventData?: mapboxgl.EventData): this {
-    this._mapProvider.zoomTo(zoom, options, eventData);
     return this;
   }
 
@@ -1165,7 +950,7 @@ export class ArlasMapGL extends AbstractArlasMapGL implements MapOverride {
     return this;
   }
 
-  public  addSource(id: string, source: AnySourceData): this {
+  public addSource(id: string, source: AnySourceData): this {
     this._mapProvider.addSource(id, source);
     return this;
   }

--- a/projects/arlas-components/src/lib/components/mapgl/model/map.type.ts
+++ b/projects/arlas-components/src/lib/components/mapgl/model/map.type.ts
@@ -41,10 +41,6 @@ export interface MapOverride {
     position?: 'top-right' | 'top-left' | 'bottom-right' | 'bottom-left',
   ): this;
 
-  removeControl(control: unknown): this;
-
-  hasControl(control: unknown): boolean;
-
   resize(eventData?: unknown): this;
 
   getBounds(): unknown;
@@ -61,27 +57,9 @@ export interface MapOverride {
 
   getMaxZoom(): number;
 
-  setMinPitch(minPitch?: number | null): this;
-
-  getMinPitch(): number;
-
-  setMaxPitch(maxPitch?: number | null): this;
-
-  getMaxPitch(): number;
-
-  getRenderWorldCopies(): boolean;
-
-  setRenderWorldCopies(renderWorldCopies?: boolean): this;
-
   project(lnglat: unknown): unknown;
 
   unproject(point: unknown): unknown;
-
-  isMoving(): boolean;
-
-  isZooming(): boolean;
-
-  isRotating(): boolean;
 
   /**
    * Returns an array of GeoJSON Feature objects representing visible features that satisfy the query parameters.
@@ -130,34 +108,6 @@ export interface MapOverride {
     options?: { layers?: string[] | undefined; filter?: any[] | undefined; } & unknown,
   ): unknown[];
 
-  /**
-   * Returns an array of GeoJSON Feature objects representing features within
-   * the specified vector tile or GeoJSON source that satisfy the query parameters.
-   *
-   * In contrast to Map#queryRenderedFeatures,
-   * this function returns all features matching the query parameters,
-   * whether or not they are rendered by the current style (i.e. visible).
-   * The domain of the query includes all currently-loaded vector tiles and
-   * GeoJSON source tiles: this function does not check tiles outside the currently visible viewport.
-   *
-   * Because features come from tiled vector
-   * data or GeoJSON data that is converted to tiles internally,
-   * feature geometries may be split or duplicated across tile boundaries and,
-   * as a result, features may appear multiple times in query results. For example,
-   * suppose there is a highway running through the bounding rectangle of a query. The
-   * results of the query will be those parts of the highway that lie within the map tiles
-   * covering the bounding rectangle, even if the highway extends into other tiles, and the
-   * portion of the highway within each map tile will be returned as a separate feature. Similarly,
-   * a point feature near a tile boundary may appear in multiple tiles due to tile buffering.
-   *
-   * @param sourceID The ID of the vector tile or GeoJSON source to query.
-   * @param parameters
-   */
-  querySourceFeatures(
-    sourceID: string,
-    parameters?: unknown,
-  ): unknown[];
-
   setStyle(
     style: unknown,
     options?: { diff?: boolean | undefined; localIdeographFontFamily?: string | undefined; },
@@ -165,13 +115,7 @@ export interface MapOverride {
 
   getStyle(): unknown;
 
-  isStyleLoaded(): boolean;
-
   addSource(id: string, source: unknown): this;
-
-  isSourceLoaded(id: string): boolean;
-
-  areTilesLoaded(): boolean;
 
   removeSource(id: string): this;
 
@@ -188,13 +132,8 @@ export interface MapOverride {
     options?: { pixelRatio?: number | undefined; sdf?: boolean | undefined; },
   ): this;
 
-  hasImage(name: string): boolean;
-
-  removeImage(name: string): this;
-
   loadImage(url: string, callback: Function): this;
 
-  listImages(): string[];
 
   addLayer(layer: unknown, before?: string): this;
 
@@ -206,19 +145,7 @@ export interface MapOverride {
 
   setFilter(layer: string, filter?: any[] | boolean | null, options?: unknown | null): this;
 
-  setLayerZoomRange(layerId: string, minzoom: number, maxzoom: number): this;
-
-  getFilter(layer: string): any[];
-
-  setPaintProperty(layer: string, name: string, value: any, options?: unknown): this;
-
-  getPaintProperty(layer: string, name: string): any;
-
   setLayoutProperty(layer: string, name: string, value: any, options?: unknown): this;
-
-  getLayoutProperty(layer: string, name: string): any;
-
-  setLight(light: unknown, options?: unknown): this;
 
   getLight(): unknown;
 
@@ -237,17 +164,9 @@ export interface MapOverride {
 
   getCanvas(): HTMLCanvasElement;
 
-  loaded(): boolean;
-
-  remove(): void;
-
-  triggerRepaint(): void;
-
   getCenter(): unknown;
 
   setCenter(center: unknown, unknown?: unknown): this;
-
-  panBy(offset: unknown, options?: unknown, unknown?: unknown): this;
 
   panTo(lnglat: unknown, options?: unknown, unknown?: unknown): this;
 
@@ -255,48 +174,12 @@ export interface MapOverride {
 
   setZoom(zoom: number, unknown?: unknown): this;
 
-  zoomTo(zoom: number, options?: unknown, unknown?: unknown): this;
-
-  zoomIn(options?: unknown, unknown?: unknown): this;
-
-  zoomOut(options?: unknown, unknown?: unknown): this;
 
   getBearing(): number;
 
   setBearing(bearing: number, unknown?: unknown): this;
 
-  /**
-   * Returns the current padding applied around the map viewport.
-   *
-   * @memberof Map#
-   * @returns The current padding around the map viewport.
-   */
-  getPadding(): unknown;
-
-  /**
-   * Sets the padding in pixels around the viewport.
-   *
-   * Equivalent to `jumpTo({padding: padding})`.
-   *
-   * @memberof Map#
-   * @param padding The desired padding. Format: { left: number, right: number, top: number, bottom: number }
-   * @param unknown Additional properties to be added to event objects of events triggered by this method.
-   * @fires movestart
-   * @fires moveend
-   * @returns {Map} `this`
-   * @example
-   * // Sets a left padding of 300px, and a top padding of 50px
-   * map.setPadding({ left: 300, top: 50 });
-   */
-  setPadding(padding: unknown, unknown?: unknown): this;
-
   rotateTo(bearing: number, options?: unknown, unknown?: unknown): this;
-
-  resetNorth(options?: unknown, unknown?: unknown): this;
-
-  resetNorthPitch(options?: unknown | null, unknown?: unknown | null): this;
-
-  snapToNorth(options?: unknown, unknown?: unknown): this;
 
   getPitch(): number;
 
@@ -306,23 +189,10 @@ export interface MapOverride {
 
   fitBounds(bounds: unknown, options?: unknown, unknown?: unknown): this;
 
-  fitScreenCoordinates(
-    p0: unknown,
-    p1: unknown,
-    bearing: number,
-    options?: unknown,
-    unknown?: unknown,
-  ): this;
-
-  jumpTo(options: unknown, unknown?: unknown): this;
 
   easeTo(options: unknown, unknown?: unknown): this;
 
   flyTo(options: unknown, unknown?: unknown): this;
-
-  isEasing(): boolean;
-
-  stop(): this;
 
   on<T extends keyof unknown>(
     type: T,
@@ -340,11 +210,4 @@ export interface MapOverride {
   once<T extends keyof unknown>(type: T, listener: (ev: unknown) => void): this;
   once(type: string, listener: (ev: any) => void): this;
 
-  off<T extends keyof unknown>(
-    type: T,
-    layer: string,
-    listener: (ev: unknown) => void,
-  ): this;
-  off<T extends keyof unknown>(type: T, listener: (ev: unknown) => void): this;
-  off(type: string, listener: (ev: any) => void): this;
 }


### PR DESCRIPTION
@MAudelGisaia 
- I renamed the ArlasMapGl to ArlasMapboxGl
- I made the abstractMapgl class implement the MapOverride instead of the ArlasMapboxGl
- I still didn't remove all the methods we dont neeed to implement from the interface