### PR TITLE
fix: correct return type of getSource

### DIFF
--- a/projects/arlas-mapbox/src/lib/arlas-mapbox.service.ts
+++ b/projects/arlas-mapbox/src/lib/arlas-mapbox.service.ts
@@ -461,7 +461,7 @@ export class ArlasMapboxService extends ArlasMapFrameworkService<ArlasAnyLayer, 
   }
 
   public getSource(sourceId: string, map: ArlasMapboxGL) {
-    return map.getMapProvider().getSource(sourceId);
+    return map.getMapProvider().getSource(sourceId) as MapboxSourceType | GeoJSONSource | GeoJSONSourceRaw;
   }
 
   /**

--- a/projects/arlas-maplibre/src/lib/arlas-maplibre.service.ts
+++ b/projects/arlas-maplibre/src/lib/arlas-maplibre.service.ts
@@ -574,12 +574,7 @@ export class ArlasMaplibreService extends ArlasMapFrameworkService<TypedStyleLay
   }
 
   public getSource(sourceId: string, map: ArlasMaplibreGL) {
-    return (map as AbstractArlasMapGL).getMapProvider().getSource(sourceId);
+    return map.getMapProvider()
+      .getSource(sourceId) as MaplibreSourceType | GeoJSONSource | RasterSourceSpecification | SourceSpecification | CanvasSourceSpecification;
   }
-
-
-
-
-
-
 }


### PR DESCRIPTION
`getSource` is supposed to return M as a type, but it could return something else