### PR TITLE
fix: increase the size of the font in map legend

### DIFF
--- a/projects/arlas-map/src/lib/arlas-map.component.scss
+++ b/projects/arlas-map/src/lib/arlas-map.component.scss
@@ -16,6 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+@import "../../assets/styles/sizes.scss";
 
 .map__container {
   width: 100%;
@@ -71,6 +72,7 @@
   justify-content: space-between;
   padding: 1px 5px 1px 0px;
   font-weight: 550;
+  font-size: $default-font-size;
   cursor: grab;
 
   &:hover .map__visu-toggle .map__visu-drag {

--- a/projects/arlas-map/src/lib/legend/legend-icon/layer-icon.component.ts
+++ b/projects/arlas-map/src/lib/legend/legend-icon/layer-icon.component.ts
@@ -151,12 +151,12 @@ export function drawFeatureFillIcon(svgNode: SVGElement, colorLegend: Legend, st
     strokeColor = getOneColor(strokeColorLegend);
   }
   const polygon = [
-    { 'x': 0, 'y': 0 },
-    { 'x': 18, 'y': 0 },
-    { 'x': 13, 'y': 15 },
-    { 'x': 1, 'y': 15 },
-    { 'x': 8, 'y': 7 },
-    { 'x': 0, 'y': 0 }];
+    { 'x': 0, 'y': 2 },
+    { 'x': 18, 'y': 2 },
+    { 'x': 13, 'y': 18 },
+    { 'x': 1, 'y': 18 },
+    { 'x': 8, 'y': 9 },
+    { 'x': 0, 'y': 2 }];
   const svg = select(svgNode);
   svg.selectAll('g').remove();
   svg.append('g').selectAll('polygon')

--- a/projects/arlas-map/src/lib/legend/legend-item/legend-item.component.scss
+++ b/projects/arlas-map/src/lib/legend/legend-item/legend-item.component.scss
@@ -20,9 +20,11 @@
 @import "../../../../assets/styles/sizes.scss";
 
 .legend {
+    padding-bottom: 2px;
+
     &__title {
         text-align: center;
-        font-size: $xs-font-size;
+        font-size: $sm-font-size;
         color: #666;
 
         text-overflow: ellipsis;
@@ -63,7 +65,7 @@
             }
 
             &__key {
-                font-size: $xs-font-size;
+                font-size: $sm-font-size;
                 margin-left: 5px;
                 flex: 1;
                 white-space: nowrap;
@@ -75,6 +77,7 @@
 
     &--interpolated {
         height: 100%;
+        padding-top: 5px;
 
         &__palette {
             height: 5px;
@@ -87,9 +90,10 @@
         &__range {
             display: flex;
             justify-content: space-between;
+            padding-top: 2.5px;
 
             &__value {
-                font-size: $xxs-font-size;
+                font-size: $sm-font-size;
                 color: #666;
             }
         }

--- a/projects/arlas-map/src/lib/legend/legend.component.scss
+++ b/projects/arlas-map/src/lib/legend/legend.component.scss
@@ -16,10 +16,10 @@
  * specific language governing permissions and limitations
  * under the License.
  */
- @import "../../../assets/styles/sizes.scss";
+@import "../../../assets/styles/sizes.scss";
 
 .layer_name {
-  font-size: $sm-font-size;
+  font-size: $default-font-size;
 }
 
 .layer_wrapper {
@@ -44,7 +44,7 @@
 }
 .layer_icon_container {
   display: flex;
-  padding-left: 3px;
+  padding-left: 5px;
 }
 .layer_detail {
   display: flex;


### PR DESCRIPTION
- Fix #959 

Side changes:
- slightly increase the size of the polygon icon in the legend to center it