### PR TITLE
fix: use ESC key to escape drawing/editing

### DIFF
--- a/projects/arlas-map/src/lib/arlas-map.component.ts
+++ b/projects/arlas-map/src/lib/arlas-map.component.ts
@@ -487,8 +487,13 @@ export class ArlasMapComponent<L, S, M> {
     drawPolygonLayers.forEach(layerId => {
       this.mapFrameworkService.onLayerEvent('mousemove', this.map, layerId, (e) =>
         this.mapFrameworkService.setMapCursor(this.map, 'pointer'));
-      this.mapFrameworkService.onLayerEvent('mouseleave', this.map, layerId, (e) =>
-        this.mapFrameworkService.setMapCursor(this.map, ''));
+      this.mapFrameworkService.onLayerEvent('mouseleave', this.map, layerId, (e) => {
+        if (this.drawService.isDrawing()) {
+          this.mapFrameworkService.setMapCursor(this.map, 'crosshair');
+        } else {
+          this.mapFrameworkService.setMapCursor(this.map, '');
+        }
+      });
     });
   }
 

--- a/projects/arlas-map/src/lib/draw/arlas-draw.component.ts
+++ b/projects/arlas-map/src/lib/draw/arlas-draw.component.ts
@@ -744,6 +744,9 @@ export class ArlasDrawComponent<L, S, M> implements OnInit {
         this.drawService.isDrawingStrip = false;
         this.drawService.isDrawingPolygon = false;
         this.draw.changeMode('static');
+      } else if (this.drawService.isInSimpleDrawMode) {
+        this.drawService.isInSimpleDrawMode = false;
+        this.draw.changeMode('simple_select', { featureIds: [] });
       }
     }
   }

--- a/projects/arlas-map/src/lib/draw/draw.service.ts
+++ b/projects/arlas-map/src/lib/draw/draw.service.ts
@@ -70,6 +70,10 @@ export class MapboxAoiDrawService {
     };
   }
 
+  public isDrawing() {
+    return this.isDrawingBbox || this.isDrawingCircle || this.isDrawingPolygon || this.isDrawingStrip;
+  }
+
   public drawBbox(fCorner: Corner, sCorner: Corner) {
     const west = Math.min(fCorner.lng, sCorner.lng);
     const east = Math.max(fCorner.lng, sCorner.lng);
@@ -136,6 +140,11 @@ export class MapboxAoiDrawService {
   public deleteAll() {
     this.registeringMode = true;
     this.mapDraw.deleteAll();
+  }
+
+  /** Deletes all the features from Mapboxdraw object that have not been saved */
+  public deleteUnregisteredFeatures() {
+    this.mapDraw.delete(this.getUnregistredFeatures().map(f => f.id.toString()));
   }
 
   /** Returns the area of the given feature */
@@ -322,7 +331,7 @@ export class MapboxAoiDrawService {
    */
   public isValidCircle(feature): boolean {
     const coordinates = feature.geometry.coordinates;
-    return this.isCircle(feature) && coordinates && coordinates[0] !== null && feature.properties.center;
+    return this.isCircle(feature) && coordinates && coordinates[0] !== null && coordinates[0][0] !== null && feature.properties.center;
   }
 
   public isValidPolygon(feature): boolean {

--- a/projects/arlas-map/src/lib/draw/modes/circles/radius.circle.mode.ts
+++ b/projects/arlas-map/src/lib/draw/modes/circles/radius.circle.mode.ts
@@ -28,7 +28,7 @@ export const radiusCircleMode = { ...MapboxDraw.modes.draw_line_string };
 
 radiusCircleMode.fireOnStop = function () {
     this.map.fire('draw.onStop', 'draw end');
-  };
+};
 
 
 function getDisplayMeasurements(feature) {
@@ -105,7 +105,6 @@ radiusCircleMode.onSetup = function (opts) {
         },
     });
     this.addFeature(polygon);
-
 
     return {
         ...props,

--- a/projects/arlas-map/src/lib/draw/modes/strip/strip.direct.mode.ts
+++ b/projects/arlas-map/src/lib/draw/modes/strip/strip.direct.mode.ts
@@ -78,7 +78,13 @@ stripDirectSelectMode.onSetup = function (opts) {
         uncombineFeatures: false,
         trash: true
     });
+    this.addFeature(feature);
+
     return state;
+};
+
+stripDirectSelectMode.fireOnStop = function () {
+    this.map.fire('draw.onStop', 'draw end');
 };
 
 stripDirectSelectMode.toDisplayFeatures = function (state, geojson, push) {
@@ -108,6 +114,7 @@ stripDirectSelectMode.toDisplayFeatures = function (state, geojson, push) {
 stripDirectSelectMode.onStop = function () {
     MapboxDraw.lib.doubleClickZoom.enable(this);
     this.clearSelectedCoordinates();
+    this.fireOnStop();
 };
 
 stripDirectSelectMode.pathsToCoordinates = function (featureId, paths) {

--- a/projects/arlas-map/src/lib/draw/modes/strip/strip.mode.ts
+++ b/projects/arlas-map/src/lib/draw/modes/strip/strip.mode.ts
@@ -125,7 +125,6 @@ stripMode.onSetup = function (opts) {
     });
     this.addFeature(polygon);
 
-
     return {
         ...props,
         strip: polygon,
@@ -133,6 +132,10 @@ stripMode.onSetup = function (opts) {
         maxLength,
         meta: 'strip'
     };
+};
+
+stripMode.fireOnStop = function () {
+    this.map.fire('draw.onStop', 'draw end');
 };
 
 stripMode.clickAnywhere = function (state, e) {
@@ -215,6 +218,7 @@ stripMode.onStop = function (state) {
         this.deleteFeature([state.line.id], { silent: true });
         this.changeMode('simple_select', {}, { silent: true });
     }
+    this.fireOnStop();
 };
 
 stripMode.toDisplayFeatures = function (state, geojson, display) {

--- a/projects/arlas-mapbox/src/lib/map/ArlasMapboxGL.ts
+++ b/projects/arlas-mapbox/src/lib/map/ArlasMapboxGL.ts
@@ -143,7 +143,7 @@ export class ArlasMapboxGL extends AbstractArlasMapGL {
       this.addControl(addGeoBoxButton, config.addGeoBox?.position ?? 'top-right', config.addGeoBox?.overrideEvent);
 
     }
-    if (config.addGeoBox.enable) {
+    if (config.removeAois.enable) {
       const removeAoisButton = new MapBoxControlButton('removeaois');
       this.addControl(removeAoisButton, config.removeAois?.position ?? 'top-right', config.removeAois?.overrideEvent);
     }

--- a/projects/arlas-maplibre/src/lib/map/ArlasMaplibreGL.ts
+++ b/projects/arlas-maplibre/src/lib/map/ArlasMaplibreGL.ts
@@ -321,7 +321,7 @@ export class ArlasMaplibreGL extends AbstractArlasMapGL {
       this.addControl(addGeoBoxButton, config.addGeoBox?.position ?? 'top-right', config.addGeoBox?.overrideEvent);
 
     }
-    if (config.addGeoBox.enable) {
+    if (config.removeAois.enable) {
       const removeAoisButton = new MaplibreControlButton('removeaois');
       this.addControl(removeAoisButton, config.removeAois?.position ?? 'top-right', config.removeAois?.overrideEvent);
     }


### PR DESCRIPTION
- Fix gisaia/ARLAS-wui#965
- Fix gisaia/ARLAS-wui#969

Side changes:
- When hovering the map with AOIs in edit mode, use the correct cursor
- Use correct cursor when drawing AOIs
- Fix copy/paste typo for `removeaois` control