### PR TITLE
feat: handle sub 1000 numbers with shorten pipe

### DIFF
--- a/projects/arlas-components/src/lib/components/componentsUtils.ts
+++ b/projects/arlas-components/src/lib/components/componentsUtils.ts
@@ -41,6 +41,13 @@ export function formatNumber(x, formatChar = ' '): string {
 export const NUMBER_FORMAT_CHAR = 'NUMBER_FORMAT_CHAR';
 
 export function numberToShortValue(number: number, p?: number): string {
+  if (Math.abs(number) < 1000) {
+    if (Math.round(number) === number) {
+      return number.toFixed(0);
+    }
+    return number.toFixed(p);
+  }
+
   // what tier? (determines SI symbol)
   const suffixes = ['', 'k', 'M', 'b', 't'];
   const suffixNum = Math.log10(Math.abs(number)) / 3 | 0;


### PR DESCRIPTION
Allows to remove `numberToShortString` in toolkit and to have a better `shortenNumber` pipe

- Fix #990