### PR TITLE
feat: allow user to resize columns

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8570,9 +8570,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.18",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.18.tgz",
-      "integrity": "sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==",
+      "version": "4.12.25",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.25.tgz",
+      "integrity": "sha512-2NFaIyNVgJmBs/ecmtGzlmluTFs5cHEWGTdu0t1HBwYzoGXOL5nUQBRMXsXWla5i4KkG//QMzVP88m1+I3fdAQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -11593,9 +11593,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
-      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -12724,9 +12724,9 @@
       "license": "MIT"
     },
     "node_modules/tmp": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
-      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+      "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/projects/arlas-components/assets/styles.css
+++ b/projects/arlas-components/assets/styles.css
@@ -25,6 +25,8 @@ body {
   --mat-dialog-actions-alignment: end;
   --mat-dialog-headline-padding: 10px 0;
 
+  --arlas-resultilist-border-color: #e9ecef;
+
   .mdc-dialog__surface {
     padding: 12px 24px;
   }

--- a/projects/arlas-components/src/lib/components/results/model/column.ts
+++ b/projects/arlas-components/src/lib/components/results/model/column.ts
@@ -61,7 +61,12 @@ export class Column {
    */
   public useColorService = false;
 
-  public constructor(columnName: string, fieldName: string, dataType: string ) {
+  /** Whether the column can be resized */
+  public get isResizable() {
+    return !this.isIdField && !this.isToggleField;
+  }
+
+  public constructor(columnName: string, fieldName: string, dataType: string) {
     this.columnName = columnName;
     this.fieldName = fieldName;
     this.dataType = dataType;

--- a/projects/arlas-components/src/lib/components/results/result-item/result-item.component.scss
+++ b/projects/arlas-components/src/lib/components/results/result-item/result-item.component.scss
@@ -23,6 +23,8 @@
   text-align: left;
   vertical-align: middle;
   box-sizing: border-box;
+  // Space for the anchor
+  padding-left: 5px;
 }
 
 .resultitem__cell__toggle--icon /* @doc Sets the toggle icon style.*/

--- a/projects/arlas-components/src/lib/components/results/result-list/result-list.component.html
+++ b/projects/arlas-components/src/lib/components/results/result-list/result-list.component.html
@@ -1,4 +1,4 @@
-<table [style.width.px]="tableWidth" class="resultlist">
+<table [style.width.px]="tableWidth" class="resultlist" [arlasResizableColumn]="true" [columns]="columns">
   @if (displayThead) {
     <thead>
       @if (displayFilters) {
@@ -105,20 +105,15 @@
       @if (resultMode !== ModeEnum.grid) {
         <tr class="resultlist__header resultlist__thead__tr">
           @for (column of columns; track column) {
-            @if (column.isIdField) {
+            @if (column.isIdField || column.isToggleField) {
               <th [style.max-width.px]="column.width" [style.min-width.px]="column.width"
-                  scope="col" class="resultlist__header--columns">
+                  scope="col" class="resultlist__header--columns" [arlasResizable]="column.columnName" [allowResize]="false">
                 <span class="resultlist__header--columns--hidden"></span>
-              </th>
-            } @else if (column.isToggleField) {
-              <th class="resultlist__header--columns" [style.max-width.px]="column.width"
-                  scope="col" [style.min-width.px]="column.width">
-                <span class="resultlist__header--columns--hidden">
-                </span>
               </th>
             } @else {
               <th [style.max-width.px]="column.width" [style.min-width.px]="column.width" class="resultlist__header--columns"
-                  scope="col" [matTooltip]="(column.columnName | translate) + (!!column.dataType ? '(' + column.dataType + ')' : '')">
+                  scope="col" [matTooltip]="(column.columnName | translate) + (!!column.dataType ? '(' + column.dataType + ')' : '')"
+                  [arlasResizable]="column.columnName">
                 <span>
                   {{column.columnName | translate}}{{column.dataType ? ' (' + column.dataType + ')': ''}}
                 </span>

--- a/projects/arlas-components/src/lib/components/results/result-list/result-list.component.html
+++ b/projects/arlas-components/src/lib/components/results/result-list/result-list.component.html
@@ -1,4 +1,4 @@
-<table [style.width.px]="tableWidth" class="resultlist" [arlasResizableColumn]="true" [columns]="columns">
+<table [style.width.px]="tableWidth" class="resultlist" [arlasResizableTable]="true" [columns]="columns">
   @if (displayThead) {
     <thead>
       @if (displayFilters) {
@@ -107,13 +107,13 @@
           @for (column of columns; track column) {
             @if (column.isIdField || column.isToggleField) {
               <th [style.max-width.px]="column.width" [style.min-width.px]="column.width"
-                  scope="col" class="resultlist__header--columns" [arlasResizable]="column.columnName" [allowResize]="false">
+                  scope="col" class="resultlist__header--columns" [arlasResizableColumn]="column.columnName" [allowResize]="false">
                 <span class="resultlist__header--columns--hidden"></span>
               </th>
             } @else {
               <th [style.max-width.px]="column.width" [style.min-width.px]="column.width" class="resultlist__header--columns"
                   scope="col" [matTooltip]="(column.columnName | translate) + (!!column.dataType ? '(' + column.dataType + ')' : '')"
-                  [arlasResizable]="column.columnName">
+                  [arlasResizableColumn]="column.columnName">
                 <span>
                   {{column.columnName | translate}}{{column.dataType ? ' (' + column.dataType + ')': ''}}
                 </span>

--- a/projects/arlas-components/src/lib/components/results/result-list/result-list.component.scss
+++ b/projects/arlas-components/src/lib/components/results/result-list/result-list.component.scss
@@ -16,6 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+@use "../utils/resizable-column";
 
 .resultlist__header {
   text-align: center;
@@ -32,6 +33,8 @@
   text-overflow: ellipsis;
   white-space: nowrap;
   box-sizing: border-box;
+  // Space for the anchor
+  padding-left: 5px;
 }
 
 .resultlist__header--columns__sort {
@@ -84,28 +87,29 @@
 
 .resultlist__body--item /* @doc Sets a row border style. (list mode)*/
 {
-  border-top: 1px solid #e9ecef;
-  border-bottom: 1px dashed #e9ecef;
+  border-top: 1px solid var(--arlas-resultilist-border-color);
+  border-bottom: 1px dashed var(--arlas-resultilist-border-color);
 }
 
 .resultlist__body--item-hover-true {
-  border-top: 1px solid #e9ecef;
-  border-bottom: 1px dashed #e9ecef;
+  border-top: 1px solid var(--arlas-resultilist-border-color);
+  border-bottom: 1px dashed var(--arlas-resultilist-border-color);
   background-color: #fff;
   position: relative;
   font-weight: 500;
 }
 
 .resultlist__body--item-hover- {
-  border-top: 1px solid #e9ecef;
-  border-bottom: 1px dashed #e9ecef;
+  border-top: 1px solid var(--arlas-resultilist-border-color);
+  border-bottom: 1px dashed var(--arlas-resultilist-border-color);
   position: relative;
   background-color: #fff;
+  display: flex;
 }
 
 .resultlist__body--item-hover-false {
-  border-top: 1px solid #e9ecef;
-  border-bottom: 1px dashed #e9ecef;
+  border-top: 1px solid var(--arlas-resultilist-border-color);
+  border-bottom: 1px dashed var(--arlas-resultilist-border-color);
   position: relative;
   background-color: #eee;
   color: #aaa;
@@ -129,14 +133,14 @@ tr {
 
 .resultlist__lastline /* @doc Sets the last row border style. (list mode)*/
 {
-  border-top: 1px dashed #e9ecef;
-  border-bottom: 0px solid #e9ecef;
+  border-top: 1px dashed var(--arlas-resultilist-border-color);
+  border-bottom: 0px solid var(--arlas-resultilist-border-color);
 }
 
 .resultlist__body--detailed-item /* @doc Sets the last row border style. (list mode)*/
 {
-  border-top: 1px dashed #e9ecef;
-  border-bottom: 1px solid #e9ecef;
+  border-top: 1px dashed var(--arlas-resultilist-border-color);
+  border-bottom: 1px solid var(--arlas-resultilist-border-color);
   background-color: #fff;
 }
 
@@ -145,8 +149,8 @@ tr {
 .resultlist__tools, /* @doc Sets the border style of the tools list container (select-all, select-in-between, grid-list-mode, ...).*/
 .resultlist__grid-detail /* @doc Sets the detail grid border style.*/
 {
-  border-top: 1px solid #e9ecef;
-  border-bottom: 1px solid #e9ecef;
+  border-top: 1px solid var(--arlas-resultilist-border-color);
+  border-bottom: 1px solid var(--arlas-resultilist-border-color);
 }
 
 .resultlist__tools {

--- a/projects/arlas-components/src/lib/components/results/result-list/result-list.component.ts
+++ b/projects/arlas-components/src/lib/components/results/result-list/result-list.component.ts
@@ -20,7 +20,8 @@
 import { AsyncPipe } from '@angular/common';
 import {
   AfterViewInit, ChangeDetectorRef, Component, DoCheck, ElementRef, EventEmitter, HostListener, Input,
-  IterableDiffers, OnChanges, OnInit, Output, SimpleChanges, ViewEncapsulation
+  IterableDiffers, OnChanges, OnInit, Output,
+  SimpleChanges, ViewEncapsulation
 } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { MatButtonModule } from '@angular/material/button';
@@ -52,6 +53,7 @@ import { ModeEnum } from '../utils/enumerations/modeEnum';
 import { PageEnum } from '../utils/enumerations/pageEnum';
 import { SortEnum } from '../utils/enumerations/sortEnum';
 import { ThumbnailFitEnum } from '../utils/enumerations/thumbnailFitEnum';
+import { ResizableColumnDirective, ResizableDirective } from '../utils/resizable-column.directive';
 import {
   Action, ElementIdentifier, FieldsConfiguration, ItemDataType,
   matchAndReplace, PageQuery, ResultListOptions
@@ -80,7 +82,8 @@ export interface SortedColumn {
     ResultFilterComponent, MatTooltip, MatCheckbox, MatIcon, MatMenuTrigger, MatMenu, MatMenuItem,
     MatSlideToggle, MatSelect, FormsModule, MatSelectTrigger, MatOption, MatButtonToggleGroup, MatButtonModule,
     MatButtonToggle, ResultDetailedGridComponent, MatProgressSpinner, ResultScrollDirective, MatGridList,
-    ResultItemComponent, ResultDetailedItemComponent, MatGridTile, ResultGridTileComponent, AsyncPipe, TranslatePipe]
+    ResultItemComponent, ResultDetailedItemComponent, MatGridTile, ResultGridTileComponent, AsyncPipe, TranslatePipe,
+    ResizableColumnDirective, ResizableDirective]
 })
 export class ResultListComponent implements OnInit, DoCheck, OnChanges, AfterViewInit {
 

--- a/projects/arlas-components/src/lib/components/results/result-list/result-list.component.ts
+++ b/projects/arlas-components/src/lib/components/results/result-list/result-list.component.ts
@@ -53,7 +53,7 @@ import { ModeEnum } from '../utils/enumerations/modeEnum';
 import { PageEnum } from '../utils/enumerations/pageEnum';
 import { SortEnum } from '../utils/enumerations/sortEnum';
 import { ThumbnailFitEnum } from '../utils/enumerations/thumbnailFitEnum';
-import { ResizableColumnDirective, ResizableDirective } from '../utils/resizable-column.directive';
+import { ResizableColumnDirective, ResizableTableDirective } from '../utils/resizable-column.directive';
 import {
   Action, ElementIdentifier, FieldsConfiguration, ItemDataType,
   matchAndReplace, PageQuery, ResultListOptions
@@ -83,7 +83,7 @@ export interface SortedColumn {
     MatSlideToggle, MatSelect, FormsModule, MatSelectTrigger, MatOption, MatButtonToggleGroup, MatButtonModule,
     MatButtonToggle, ResultDetailedGridComponent, MatProgressSpinner, ResultScrollDirective, MatGridList,
     ResultItemComponent, ResultDetailedItemComponent, MatGridTile, ResultGridTileComponent, AsyncPipe, TranslatePipe,
-    ResizableColumnDirective, ResizableDirective]
+    ResizableColumnDirective, ResizableTableDirective]
 })
 export class ResultListComponent implements OnInit, DoCheck, OnChanges, AfterViewInit {
 

--- a/projects/arlas-components/src/lib/components/results/utils/resizable-column.directive.ts
+++ b/projects/arlas-components/src/lib/components/results/utils/resizable-column.directive.ts
@@ -43,13 +43,13 @@ const TABLE_ANCHOR_CSS_PRETTY_NAME = 'arlas-resizable-anchor';
  * Directive to declare a table with resizable columns
  */
 @Directive({
-  selector: '[arlasResizableColumn]'
+  selector: '[arlasResizableTable]'
 })
-export class ResizableColumnDirective implements AfterViewInit, OnDestroy, OnInit {
+export class ResizableTableDirective implements AfterViewInit, OnDestroy, OnInit {
   /**
    * Whether the columns of the table can be resized
    */
-  public arlasResizableColumn = input(true);
+  public arlasResizableTable = input(true);
 
   /**
    * Source of truth that helps to keep the column ordered
@@ -59,7 +59,7 @@ export class ResizableColumnDirective implements AfterViewInit, OnDestroy, OnIni
   /**
    * Column that needs to be resized and has the directive ResizableDirective
    */
-  protected currentResizableDirective?: ResizableDirective;
+  protected currentResizableDirective?: ResizableColumnDirective;
 
   /**
    * Mouse X position when the drag starts
@@ -72,7 +72,7 @@ export class ResizableColumnDirective implements AfterViewInit, OnDestroy, OnIni
   private cursor?: HTMLElement;
 
   /** Child directive reference */
-  private readonly childDirectiveRef = contentChildren(forwardRef(() => ResizableDirective), {descendants: true});
+  private readonly childDirectiveRef = contentChildren(forwardRef(() => ResizableColumnDirective), {descendants: true});
 
   /**
    * Store child event ref to be unsubscribed on destroy
@@ -83,7 +83,7 @@ export class ResizableColumnDirective implements AfterViewInit, OnDestroy, OnIni
   public columnResized = output<ResizableColumnMoveEvent>();
 
   /** Subject through which each child can declare themselves */
-  public readonly childrenOnInit$ = new Subject<ResizableDirective>();
+  public readonly childrenOnInit$ = new Subject<ResizableColumnDirective>();
 
   /** Destroy reference */
   private readonly destroyRef = inject(DestroyRef);
@@ -108,13 +108,13 @@ export class ResizableColumnDirective implements AfterViewInit, OnDestroy, OnIni
       .subscribe((event: Event) => {
         for (const d of this.childDirectiveRef()) {
           const width = this.getElementWidth(d.getNativeEl());
-          this.storeWidth(width, d.arlasResizable());
+          this.storeWidth(width, d.arlasResizableColumn());
         }
       });
   }
 
   public ngAfterViewInit() {
-    if (this.arlasResizableColumn()) {
+    if (this.arlasResizableTable()) {
       this.createCursor();
     }
   }
@@ -155,7 +155,7 @@ export class ResizableColumnDirective implements AfterViewInit, OnDestroy, OnIni
 
         // If the column after cannot be resized, then this one can only be resized using the handle before it
         if (!child.allowResize() && index > 0) {
-          (this.childDirectiveRef()[index - 1] as ResizableDirective).removeAnchor();
+          (this.childDirectiveRef()[index - 1] as ResizableColumnDirective).removeAnchor();
         }
         index++;
     });
@@ -163,10 +163,10 @@ export class ResizableColumnDirective implements AfterViewInit, OnDestroy, OnIni
 
   /**
    * Bind all necessary event to track column resize
-   * @param {ResizableDirective} childDirective
+   * @param childDirective
    * @private
    */
-  private bindColumnResizeEvents(childDirective: ResizableDirective) {
+  private bindColumnResizeEvents(childDirective: ResizableColumnDirective) {
     this.eventRef.push(
       childDirective.resizing.subscribe(event => this.moveCursor(event.event)),
       childDirective.resizeStarted.subscribe(event => this.onResizeStarted(event, childDirective)),
@@ -217,7 +217,7 @@ export class ResizableColumnDirective implements AfterViewInit, OnDestroy, OnIni
    * @param event
    * @param childDirective
    */
-  private onResizeStarted(event: ResizableColumnMoveEvent, childDirective: ResizableDirective) {
+  private onResizeStarted(event: ResizableColumnMoveEvent, childDirective: ResizableColumnDirective) {
     this.currentResizableDirective = childDirective;
 
     if (this.cdkDropList){
@@ -277,7 +277,7 @@ export class ResizableColumnDirective implements AfterViewInit, OnDestroy, OnIni
   }
 
   /**
-   * Get current width from a start position
+   * Get current width of the column while dragging the anchor to change its width
    * @param event Mouse position after dragging started
    * @param el Element to measure
    */
@@ -295,14 +295,14 @@ export class ResizableColumnDirective implements AfterViewInit, OnDestroy, OnIni
       const event = resizeEvent.event;
       const newWidth = this.getCurrentWidth(event, this.currentResizableDirective.getNativeEl());
 
-      const resizedColumnIdx = this.columns().findIndex(c => c.columnName === this.currentResizableDirective.arlasResizable());
+      const resizedColumnIdx = this.columns().findIndex(c => c.columnName === this.currentResizableDirective.arlasResizableColumn());
       // If the next column is resizeable
       const nextColumn = this.columns()[resizedColumnIdx + 1];
       if (resizedColumnIdx >= 0 && nextColumn.isResizable) {
         const dx = newWidth - this.columns()[resizedColumnIdx].width;
 
         if (newWidth) {
-          this.storeWidth(newWidth, this.currentResizableDirective.arlasResizable());
+          this.storeWidth(newWidth, this.currentResizableDirective.arlasResizableColumn());
           // Resize next column by -dx
           this.storeWidth(nextColumn.width - dx, nextColumn.columnName);
         }
@@ -329,13 +329,13 @@ export interface ResizableColumnMoveEvent {
  * Directive to declare the column to resize
  */
 @Directive({
-  selector: '[arlasResizable]'
+  selector: '[arlasResizableColumn]'
 })
-export class ResizableDirective implements OnInit, AfterViewInit, OnDestroy {
+export class ResizableColumnDirective implements OnInit, AfterViewInit, OnDestroy {
   /**
    * Column id
    */
-  public arlasResizable = input.required<string>();
+  public arlasResizableColumn = input.required<string>();
 
   /**
    * Whether to allow the resize of the column.
@@ -365,7 +365,7 @@ export class ResizableDirective implements OnInit, AfterViewInit, OnDestroy {
   /**
    * Resizable column directive. Mandatory to work.
    */
-  private readonly parent = inject(ResizableColumnDirective);
+  private readonly parent = inject(ResizableTableDirective);
   /**
    * Angular utility to manipulate dom
    */
@@ -421,7 +421,7 @@ export class ResizableDirective implements OnInit, AfterViewInit, OnDestroy {
     this.mouseMoveRef = this.renderer.listen('document', 'mousemove', (e: MouseEvent) => {
       e.stopPropagation();
       if (this.isResizing && this.allowResize()) {
-        this.resizing.emit({el: this.headerCellEl.nativeElement, event: e, columnName: this.arlasResizable()});
+        this.resizing.emit({el: this.headerCellEl.nativeElement, event: e, columnName: this.arlasResizableColumn()});
       }
     });
   }
@@ -433,7 +433,7 @@ export class ResizableDirective implements OnInit, AfterViewInit, OnDestroy {
     this.mouseUpRef = this.renderer.listen('document', 'mouseup', (e) => {
       e.stopPropagation();
       if (this.isResizing && this.allowResize()) {
-        this.resizeEnded.emit({el: this.headerCellEl.nativeElement, event: e, columnName: this.arlasResizable()});
+        this.resizeEnded.emit({el: this.headerCellEl.nativeElement, event: e, columnName: this.arlasResizableColumn()});
         this.isResizing = false;
         this.mouseUpRef?.();
         this.mouseMoveRef?.();
@@ -449,7 +449,7 @@ export class ResizableDirective implements OnInit, AfterViewInit, OnDestroy {
       e.stopPropagation();
       if (!this.isResizing && this.allowResize()) {
         this.isResizing = true;
-        this.resizeStarted.emit({el: this.getNativeEl(), event: e, columnName: this.arlasResizable()});
+        this.resizeStarted.emit({el: this.getNativeEl(), event: e, columnName: this.arlasResizableColumn()});
         this.mouseMove();
         this.mouseUp();
       }
@@ -457,7 +457,7 @@ export class ResizableDirective implements OnInit, AfterViewInit, OnDestroy {
   }
 
   /**
-   * Create an anchor to show where user can start to resize column
+   * Create an anchor to show where the user can start to resize column
    */
   private addAnchor() {
     const el = this.getNativeEl();
@@ -466,6 +466,9 @@ export class ResizableDirective implements OnInit, AfterViewInit, OnDestroy {
     this.renderer.appendChild(el, this.anchor);
   }
 
+  /**
+   * Remove the anchor if the column can't be resized
+   */
   public removeAnchor() {
     this.renderer.removeClass(this.anchor, TABLE_ANCHOR_CSS_PRETTY_NAME);
   }

--- a/projects/arlas-components/src/lib/components/results/utils/resizable-column.directive.ts
+++ b/projects/arlas-components/src/lib/components/results/utils/resizable-column.directive.ts
@@ -1,0 +1,472 @@
+/*
+ * Licensed to Gisaïa under one or more contributor
+ * license agreements. See the NOTICE.txt file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Gisaïa licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { CdkDropList } from '@angular/cdk/drag-drop';
+import {
+  AfterViewInit, ChangeDetectorRef, contentChildren, DestroyRef, Directive, ElementRef,
+  forwardRef, inject, input, OnDestroy, OnInit, output, OutputRefSubscription, Renderer2
+} from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { debounceTime, fromEvent, Subject } from 'rxjs';
+import { Column } from '../model/column';
+
+/** CSS class for the cursor of the resizable columns */
+const CURSOR_CSS_PRETTY_NAME = 'arlas-resizable-cursor';
+/** CSS class to make the cursor visible */
+const CURSOR_RESIZE_CSS_PRETTY_NAME = 'arlas-resizable-cursor--visible';
+/** CSS class for a resizable table */
+const TABLE_CSS_PRETTY_NAME = 'arlas-resizable-table';
+/** CSS class for a table being resized */
+const TABLE_RESIZING_CSS_PRETTY_NAME = 'arlas-resizable-table--resizing';
+/** CSS class for a header cell */
+const TABLE_HEADER_CSS_PRETTY_NAME = 'arlas-resizable-header-cell';
+/** CSS class for the anchor */
+const TABLE_ANCHOR_CSS_PRETTY_NAME = 'arlas-resizable-anchor';
+
+/**
+ * Directive to declare a table with resizable columns
+ */
+@Directive({
+  selector: '[arlasResizableColumn]'
+})
+export class ResizableColumnDirective implements AfterViewInit, OnDestroy, OnInit {
+  /**
+   * Whether the columns of the table can be resized
+   */
+  public arlasResizableColumn = input(true);
+
+  /**
+   * Source of truth that helps to keep the column ordered
+   */
+  public columns = input.required<Column[]>();
+
+  /**
+   * Column that needs to be resized and has the directive ResizableDirective
+   */
+  protected currentResizableDirective?: ResizableDirective;
+
+  /**
+   * Mouse X position when the drag starts
+   */
+  private currentStartX = -1;
+
+  /**
+   * Cursor indicator
+   */
+  private cursor?: HTMLElement;
+
+  /** Child directive reference */
+  private readonly childDirectiveRef = contentChildren(forwardRef(() => ResizableDirective), {descendants: true});
+
+  /**
+   * Store child event ref to be unsubscribed on destroy
+   */
+  private readonly eventRef: OutputRefSubscription[] = [];
+
+  /** Event triggered when the column is resized */
+  public columnResized = output<ResizableColumnMoveEvent>();
+
+  /** Subject through which each child can declare themselves */
+  public readonly childrenOnInit$ = new Subject<ResizableDirective>();
+
+  /** Destroy reference */
+  private readonly destroyRef = inject(DestroyRef);
+  /** HTML reference of the mat-table hosting the directive */
+  private readonly tableElementRef = inject(ElementRef);
+  /** Angular utility to manipulate DOM */
+  private readonly renderer = inject(Renderer2);
+  /** Cdk drop list reference */
+  private readonly cdkDropList = inject(CdkDropList, {optional: true});
+  private readonly cdr = inject(ChangeDetectorRef);
+
+  public constructor() {
+    this.listenToInitialisedChildren();
+  }
+
+  /**
+   * Updates stored widths and table width when the window is resized
+   */
+  public ngOnInit() {
+    fromEvent(globalThis, 'resize')
+      .pipe(debounceTime(100), takeUntilDestroyed(this.destroyRef))
+      .subscribe((event: Event) => {
+        for (const d of this.childDirectiveRef()) {
+          const width = this.getElementWidth(d.getNativeEl());
+          this.storeWidth(width, d.arlasResizable());
+        }
+      });
+  }
+
+  public ngAfterViewInit() {
+    if (this.arlasResizableColumn()) {
+      this.createCursor();
+    }
+  }
+
+  public ngOnDestroy() {
+    this.clearChildSubscription();
+  }
+
+  /** Gets the table's native element */
+  private getNativeEl() {
+    return this.tableElementRef.nativeElement as HTMLElement;
+  }
+
+  /**
+   * Create the HTML for the cursor
+   */
+  private createCursor() {
+    this.cursor = this.renderer.createElement('div') as HTMLElement;
+    this.renderer.addClass(this.cursor, CURSOR_CSS_PRETTY_NAME);
+    this.renderer.appendChild(this.getNativeEl(), this.cursor);
+    this.renderer.addClass(this.getNativeEl(), TABLE_CSS_PRETTY_NAME);
+  }
+
+  private clearChildSubscription() {
+    for (const ref of this.eventRef) {
+      ref.unsubscribe();
+    }
+  }
+
+  /**
+   * Listen for child update to be sure to update the width before content is created.
+   */
+  private listenToInitialisedChildren() {
+    let index = 0;
+    this.childrenOnInit$.pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((child) => {
+        this.bindColumnResizeEvents(child);
+
+        // If the column after cannot be resized, then this one can only be resized using the handle before it
+        if (!child.allowResize() && index > 0) {
+          (this.childDirectiveRef()[index - 1] as ResizableDirective).removeAnchor();
+        }
+        index++;
+    });
+  }
+
+  /**
+   * Bind all necessary event to track column resize
+   * @param {ResizableDirective} childDirective
+   * @private
+   */
+  private bindColumnResizeEvents(childDirective: ResizableDirective) {
+    this.eventRef.push(
+      childDirective.resizing.subscribe(event => this.moveCursor(event.event)),
+      childDirective.resizeStarted.subscribe(event => this.onResizeStarted(event, childDirective)),
+      childDirective.resizeEnded.subscribe((e) => this.onResizeEnded(e))
+    );
+  }
+
+  /**
+   * Store width for each column
+   * @param width Width of the column (in pixels)
+   * @param id Column name
+   */
+  private storeWidth(width: number, id: string): void {
+    const column = this.columns().find(c => c.columnName === id);
+    if (column) {
+      column.width = width;
+    }
+  }
+
+  /**
+   * Calculate child Directive width
+   * @param htmlElement
+   */
+  private getElementWidth(htmlElement: Element): number {
+   return (htmlElement as HTMLElement).offsetWidth;
+  }
+
+  /**
+   * Updates column width and resets main attributes
+   * @param {ResizableColumnMoveEvent} event
+   */
+  private onResizeEnded(event: ResizableColumnMoveEvent) {
+    this.resizeColumn(event);
+    if(this.cdkDropList){
+      this.cdkDropList.disabled = false;
+    }
+    this.columnResized.emit(event);
+
+    this.hideCursor();
+    this.currentStartX = -1;
+    this.currentResizableDirective = undefined;
+    this.renderer.removeClass(this.getNativeEl(), TABLE_RESIZING_CSS_PRETTY_NAME);
+    this.cdr.detectChanges();
+  }
+
+  /**
+   * Updates the column width and displays the cursor
+   * @param event
+   * @param childDirective
+   */
+  private onResizeStarted(event: ResizableColumnMoveEvent, childDirective: ResizableDirective) {
+    this.currentResizableDirective = childDirective;
+
+    if (this.cdkDropList){
+      this.cdkDropList.disabled = true;
+    }
+
+    this.currentStartX = event.event.pageX;
+    this.showCursor();
+    this.renderer.addClass(this.getNativeEl(), TABLE_RESIZING_CSS_PRETTY_NAME);
+  }
+
+  /**
+   * Called when user move cursor
+   * @param e
+   */
+  private moveCursor(e: MouseEvent): void {
+    this.updateCursorPosition(e);
+  }
+
+  /**
+   * Updates cursor position
+   * @param e
+   */
+  private updateCursorPosition(e: MouseEvent){
+    if (this.cursor && this.currentResizableDirective?.anchor) {
+      const tableElement = this.getNativeEl();
+      const newWidth = this.getCurrentWidth(e, this.currentResizableDirective.getNativeEl());
+      if (newWidth) {
+        const translate = `translate(${(e.pageX - tableElement.getBoundingClientRect().x)}px)`;
+        this.renderer.setStyle(this.cursor, 'transform', translate);
+      }
+    }
+  }
+
+  /**
+   * Show cursor when user click
+   */
+  private showCursor(): void {
+    if (this.cursor && this.currentResizableDirective?.anchor) {
+      const anchorPosition = this.currentResizableDirective?.anchor.getBoundingClientRect();
+      const el = this.tableElementRef.nativeElement as Element;
+      const pxLeftBetweenAnchorAndCursorSIze = 3;
+      const translate = `translate(${((anchorPosition?.x - el.getBoundingClientRect().x) + pxLeftBetweenAnchorAndCursorSIze)}px)`;
+      this.renderer.setStyle(this.cursor, 'transform', translate);
+      this.renderer.addClass(this.cursor, CURSOR_RESIZE_CSS_PRETTY_NAME);
+    }
+  }
+
+  /**
+   * Hide cursor
+   */
+  private hideCursor(): void {
+    if (this.cursor && this.currentResizableDirective?.anchor) {
+      this.renderer.setStyle(this.cursor, 'transform', 'translate(0px)');
+      this.renderer.removeClass(this.cursor, CURSOR_RESIZE_CSS_PRETTY_NAME);
+    }
+  }
+
+  /**
+   * Get current width from a start position
+   * @param event Mouse position after dragging started
+   * @param el Element to measure
+   */
+  private getCurrentWidth(event: MouseEvent, el: Element): number {
+    const deltaX = (event.pageX - this.currentStartX);
+    return this.getElementWidth(el) + deltaX;
+  }
+
+  /**
+   * Resize current column and right column
+   * @param resizeEvent
+   */
+  private resizeColumn(resizeEvent: ResizableColumnMoveEvent): void {
+    if (this.currentResizableDirective) {
+      const event = resizeEvent.event;
+      const newWidth = this.getCurrentWidth(event, this.currentResizableDirective.getNativeEl());
+
+      const resizedColumnIdx = this.columns().findIndex(c => c.columnName === this.currentResizableDirective.arlasResizable());
+      // If the next column is resizeable
+      const nextColumn = this.columns()[resizedColumnIdx + 1];
+      if (resizedColumnIdx >= 0 && nextColumn.isResizable) {
+        const dx = newWidth - this.columns()[resizedColumnIdx].width;
+
+        if (newWidth) {
+          this.storeWidth(newWidth, this.currentResizableDirective.arlasResizable());
+          // Resize next column by -dx
+          this.storeWidth(nextColumn.width - dx, nextColumn.columnName);
+        }
+      }
+    }
+  }
+}
+
+
+/**
+ * Structure of the event for a column to be resized
+ */
+export interface ResizableColumnMoveEvent {
+  /** DOM element subjected to the resize */
+  el: Element;
+  /** Type of MouseEvent leading to the resize */
+  event: MouseEvent;
+  /** Name of the column */
+  columnName: string;
+}
+
+
+/**
+ * Directive to declare the column to resize
+ */
+@Directive({
+  selector: '[arlasResizable]'
+})
+export class ResizableDirective implements OnInit, AfterViewInit, OnDestroy {
+  /**
+   * Column id
+   */
+  public arlasResizable = input.required<string>();
+
+  /**
+   * Whether to allow the resize of the column.
+   * Added so that not-resizeable columns are taken into account when updating the table width
+   */
+  public allowResize = input(true);
+  /**
+   * Header cell element reference
+   */
+  private readonly headerCellEl = inject(ElementRef);
+  /**
+   * Emit when resize starts
+   */
+  public resizeStarted = output<ResizableColumnMoveEvent>();
+  /**
+   * Emit when resize ends
+   */
+  public resizeEnded = output<ResizableColumnMoveEvent>();
+  /**
+   * Emit when we are resizing a column
+   */
+  public resizing = output<ResizableColumnMoveEvent>();
+  /**
+   * Anchor placed next to column title
+   */
+  public anchor: Element | undefined;
+  /**
+   * Resizable column directive. Mandatory to work.
+   */
+  private readonly parent = inject(ResizableColumnDirective);
+  /**
+   * Angular utility to manipulate dom
+   */
+  private readonly renderer = inject(Renderer2);
+  /**
+   * Whether we are resizing
+   */
+  private isResizing = false;
+  /**
+   * Hold mouse move event reference to be cleared when component is destroyed
+   */
+  private mouseMoveRef?: () => void;
+  /**
+   * Hold mouse up event reference to be cleared when component is destroyed
+   */
+  private mouseUpRef?: () => void;
+  /**
+   * Hold mouse down event reference to be cleared when component is destroyed
+   */
+  private mouseDownRef?: () => void;
+
+  public ngOnInit() {
+    this.parent.childrenOnInit$.next(this);
+
+    if (this.allowResize()) {
+      this.renderer.addClass(this.headerCellEl.nativeElement, TABLE_HEADER_CSS_PRETTY_NAME);
+    }
+  }
+
+  /**
+   * Get native element
+   * @returns {Element}
+   */
+  public getNativeEl(): Element {
+    return this.headerCellEl.nativeElement as Element;
+  }
+
+  public ngOnDestroy() {
+    this.mouseDownRef?.();
+  }
+
+  public ngAfterViewInit() {
+    if (this.parent && this.allowResize()) {
+      this.addAnchor();
+      this.mouseDown();
+    }
+  }
+
+  /**
+   * Initialise mousemove behavior
+   */
+  private mouseMove() {
+    this.mouseMoveRef = this.renderer.listen('document', 'mousemove', (e: MouseEvent) => {
+      e.stopPropagation();
+      if (this.isResizing && this.allowResize()) {
+        this.resizing.emit({el: this.headerCellEl.nativeElement, event: e, columnName: this.arlasResizable()});
+      }
+    });
+  }
+
+  /**
+   * Initialise mouseup behavior
+   */
+  private mouseUp() {
+    this.mouseUpRef = this.renderer.listen('document', 'mouseup', (e) => {
+      e.stopPropagation();
+      if (this.isResizing && this.allowResize()) {
+        this.resizeEnded.emit({el: this.headerCellEl.nativeElement, event: e, columnName: this.arlasResizable()});
+        this.isResizing = false;
+        this.mouseUpRef?.();
+        this.mouseMoveRef?.();
+      }
+    });
+  }
+
+  /**
+   * Initialise mousedown behavior
+   */
+  private mouseDown() {
+    this.mouseDownRef = this.renderer.listen(this.anchor, 'mousedown', (e) => {
+      e.stopPropagation();
+      if (!this.isResizing && this.allowResize()) {
+        this.isResizing = true;
+        this.resizeStarted.emit({el: this.getNativeEl(), event: e, columnName: this.arlasResizable()});
+        this.mouseMove();
+        this.mouseUp();
+      }
+    });
+  }
+
+  /**
+   * Create an anchor to show where user can start to resize column
+   */
+  private addAnchor() {
+    const el = this.getNativeEl();
+    this.anchor = this.renderer.createElement('span');
+    this.renderer.addClass(this.anchor, TABLE_ANCHOR_CSS_PRETTY_NAME);
+    this.renderer.appendChild(el, this.anchor);
+  }
+
+  public removeAnchor() {
+    this.renderer.removeClass(this.anchor, TABLE_ANCHOR_CSS_PRETTY_NAME);
+  }
+}

--- a/projects/arlas-components/src/lib/components/results/utils/resizable-column.scss
+++ b/projects/arlas-components/src/lib/components/results/utils/resizable-column.scss
@@ -1,0 +1,93 @@
+/*
+ * Licensed to Gisaïa under one or more contributor
+ * license agreements. See the NOTICE.txt file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Gisaïa licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+.arlas-resizable {
+  &-table {
+    position: relative;
+    -webkit-user-select: none; /* Safari */
+    -ms-user-select: none; /* IE 10 and IE 11 */
+    user-select: none;
+  }
+  &-table--resizing {
+    -webkit-user-select: none; /* Safari */
+    -ms-user-select: none; /* IE 10 and IE 11 */
+    user-select: none; /* Standard syntax */
+  }
+
+  &-header-cell {
+    position: relative;
+  }
+
+  &-anchor {
+    top: 0;
+    right: -5px;
+    position: absolute;
+    height: 100%;
+    width: 10px;
+    cursor: col-resize;
+    z-index: 20;
+    opacity: 1;
+  }
+
+  &-anchor-indicator {
+    position: absolute;
+    background: red;
+    height: 20px;
+    width: 20px;
+    &:after {
+      content: '';
+      display: block;
+      height: 2px;
+      width: 2px;
+      background-color: red;
+    }
+  }
+
+  &-cursor {
+    background: var(--arlas-resultilist-border-color);
+    position: absolute;
+    top: 0;
+    height: 100%;
+    width: 4px;
+    z-index: 101;
+    opacity: 0;
+    border-radius: 50px;
+    &--visible {
+      opacity: 1;
+    }
+    &:hover {
+      cursor:col-resize;
+    }
+  }
+}
+
+.arlas-resizable-table  thead th {
+  --arlas-sys-resizable-column-background: white;
+  border-right-style:  solid;
+  border-left-style:  solid;
+  border-left-width: 1px;
+  border-right-width: 1px;
+  border-left-color: var(--arlas-sys-resizable-column-background);
+  border-right-color: var(--arlas-sys-resizable-column-background);
+}
+
+.arlas-resizable-table:not(.cdk-drop-list-dragging) thead:hover th {
+  border-left-color: var(--arlas-resultilist-border-color);
+  border-right-color: var(--arlas-resultilist-border-color);
+}


### PR DESCRIPTION
- Fix gisaia/ARLAS-wui#853

Resize is allowed for all columns except the ID and toggle. A column followed by a column that can't be resized, cannot be resized as the next column width is edited to keep the table width constant.