### PR TITLE
feat: add input to customize draw polygon theme

### DIFF
--- a/projects/arlas-map/src/lib/arlas-map.component.html
+++ b/projects/arlas-map/src/lib/arlas-map.component.html
@@ -21,8 +21,8 @@
                   <div cdkDragHandle class="map__visu-layer-drag">
                     <mat-icon>drag_indicator</mat-icon>
                   </div>
-                  <arlas-legend [collection]="l | getCollection: mapService.layersMap " [enabled]="visu.enabled"
-                    [layer]="l | getValue: mapService.layersMap " [zoom]="map?.zoom"
+                  <arlas-legend [collection]="l | getCollection:mapService.layersMap" [enabled]="visu.enabled"
+                    [layer]="l | getValue:mapService.layersMap" [zoom]="map?.zoom"
                     (visibilityStatus)="emitLegendVisibility(visu.name, l, $event)" [legendUpdater]="legendUpdater"
                     [visibilityUpdater]="visibilityUpdater" [highlightLegend]="highlightLegend"
                   (downloadSourceEmitter)="downloadLayerSource($event)"></arlas-legend>
@@ -50,6 +50,7 @@
   <arlas-draw #drawComponent [map]="map" [emptyData]="emptyData" [drawData]="drawData"
     [drawButtonEnabled]="drawButtonEnabled" [drawOption]="drawOption"
     [drawPolygonVerticesLimit]="drawPolygonVerticesLimit" [preserveDrawingBuffer]="preserveDrawingBuffer"
+    [drawTheme]="drawTheme()"
     (onAoiChanged)="onAoiChanged.emit($event)"
     (onAoiEdit)="onAoiEdit.emit($event)"></arlas-draw>
 }

--- a/projects/arlas-map/src/lib/arlas-map.component.ts
+++ b/projects/arlas-map/src/lib/arlas-map.component.ts
@@ -42,6 +42,7 @@ import { CoordinatesComponent } from './coordinates/coordinates.component';
 import { ArlasDrawComponent } from './draw/arlas-draw.component';
 import { AoiEdition } from './draw/draw.models';
 import { MapboxAoiDrawService } from './draw/draw.service';
+import { DrawTheme } from './draw/themes/default-theme';
 import { LegendComponent } from './legend/legend.component';
 import { LegendData } from './legend/legend.config';
 import { LegendService } from './legend/legend.service';
@@ -190,6 +191,8 @@ export class ArlasMapComponent<L, S, M> implements AfterViewInit {
   /** @description Whether the drawing buffer is activated */
   /** If true, the map's canvas can be exported to a PNG using map.getCanvas().toDataURL(). Default: false */
   @Input() public preserveDrawingBuffer = false;
+  /** @description Theme for the drawn polygons */
+  public drawTheme = input<DrawTheme>({});
 
   /** --- ATTRIBUTION */
 

--- a/projects/arlas-map/src/lib/draw/arlas-draw.component.ts
+++ b/projects/arlas-map/src/lib/draw/arlas-draw.component.ts
@@ -17,7 +17,10 @@
  * under the License.
  */
 
-import { Component, EventEmitter, HostListener, inject, Input, OnInit, Output, signal, SimpleChanges, ViewEncapsulation } from '@angular/core';
+import {
+  Component, EventEmitter, HostListener, inject, input, Input,
+  OnInit, Output, signal, SimpleChanges, ViewEncapsulation
+} from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { marker } from '@colsen1991/ngx-translate-extract-marker';
@@ -45,7 +48,7 @@ import { rectangleMode } from './modes/rectangleMode';
 import { simpleSelectModeOverride } from './modes/simpleSelectOverride';
 import { stripDirectSelectMode } from './modes/strip/strip.direct.mode';
 import { stripMode } from './modes/strip/strip.mode';
-import * as styles from './themes/default-theme';
+import { buildDrawStyle, DrawTheme } from './themes/default-theme';
 
 @Component({
     selector: 'arlas-draw',
@@ -79,6 +82,8 @@ export class ArlasDrawComponent<L, S, M> implements OnInit {
   /** @description Whether the drawing buffer is activated */
   /** If true, the map's canvas can be exported to a PNG using map.getCanvas().toDataURL(). Default: false */
   @Input() public preserveDrawingBuffer = false;
+  /** @description Theme for the drawn polygons */
+  public drawTheme = input<DrawTheme>({});
 
   /** @description Emits the geojson of an aoi added to the map. */
   @Output() public onAoiChanged: EventEmitter<FeatureCollection<GeoJSON.Geometry>> = new EventEmitter();
@@ -263,12 +268,11 @@ export class ArlasDrawComponent<L, S, M> implements OnInit {
         }
       }
     });
-
   }
 
   public ngOnInit(): void {
     this.drawTooltipElement = document.getElementById('arlas-draw-tooltip');
-    const drawStyles = styles.default;
+    const drawStyles = buildDrawStyle(this.drawTheme());
     const drawOptions = {
       ...this.drawOption,
       styles: drawStyles,

--- a/projects/arlas-map/src/lib/draw/themes/default-theme.ts
+++ b/projects/arlas-map/src/lib/draw/themes/default-theme.ts
@@ -90,7 +90,7 @@ function buildLinePaint(color: string, dash: number[]) {
 }
 
 /**
- * Builds the style for the Mapbox draw layers
+ * Builds the style for the Mapbox/Maplibre draw layers
  * @param theme Theme summarizing the drawing styles
  */
 export function buildDrawStyle(theme: DrawTheme) {

--- a/projects/arlas-map/src/lib/draw/themes/default-theme.ts
+++ b/projects/arlas-map/src/lib/draw/themes/default-theme.ts
@@ -59,16 +59,6 @@ const staticMidpoint = ['all',
   ['==', '$type', 'Point'],
   ['!=', 'mode', 'static']
 ];
-const dashedLinePaint = {
-  'line-color': '#fbb03b',
-  'line-dasharray': [0.2, 2],
-  'line-width': 2
-};
-
-const linePaint = {
-  'line-color': '#3bb2d0',
-  'line-width': 2
-};
 
 const rotatePointFilter = ['all',
   ['==', 'meta', 'midpoint'],
@@ -76,255 +66,291 @@ const rotatePointFilter = ['all',
   ['==', '$type', 'Point'],
   ['!=', 'mode', 'static']
 ];
-export default [
-  {
-    'id': 'gl-draw-polygon-fill-inactive',
-    'type': 'fill',
-    'filter': deactivatedStaticPolygon,
-    'paint': {
-      'fill-color': '#3bb2d0',
-      'fill-outline-color': '#3bb2d0',
-      'fill-opacity': 0.1
-    }
-  },
-  {
-    'id': 'gl-draw-polygon-fill-active',
-    'type': 'fill',
-    'filter': activePolygon,
-    'paint': {
-      'fill-color': '#fbb03b',
-      'fill-outline-color': '#fbb03b',
-      'fill-opacity': 0.1
-    }
-  },
-  {
-    'id': 'gl-draw-polygon-midpoint',
-    'type': 'circle',
-    'filter': ['all',
-      ['==', '$type', 'Point'],
-      ['==', 'meta', 'midpoint']],
-    'paint': {
-      'circle-radius': 3,
-      'circle-color': '#fbb03b'
-    }
-  },
-  {
-    'id': 'gl-draw-polygon-stroke-inactive',
-    'type': 'line',
-    'filter': deactivatedStaticPolygon,
-    'layout': roundLineLayout,
-    'paint': linePaint
-  },
-  {
-    'id': 'gl-draw-polygon-stroke-active',
-    'type': 'line',
-    'filter': activePolygon,
-    'layout': roundLineLayout,
-    'paint': dashedLinePaint
-  },
-  {
-    'id': 'gl-draw-line-inactive',
-    'type': 'line',
-    'filter': ['all',
-      ['==', 'active', 'false'],
-      ['==', '$type', 'LineString'],
-      ['!=', 'mode', 'static']
-    ],
-    'layout': roundLineLayout,
 
-    'paint': linePaint
-  },
-  {
-    'id': 'gl-draw-line-active',
-    'type': 'line',
-    'filter': ['all',
-      ['==', '$type', 'LineString'],
-      ['==', 'active', 'true']
-    ],
-    'layout': roundLineLayout,
-    'paint': dashedLinePaint
-  },
-  {
-    'id': 'gl-draw-polygon-and-line-vertex-stroke-inactive',
-    'type': 'circle',
-    'filter': staticModeVertex,
-    'paint': {
-      'circle-radius': 5,
-      'circle-color': '#fff'
-    }
-  },
-  {
-    'id': 'gl-draw-polygon-and-line-vertex-inactive',
-    'type': 'circle',
-    'filter': staticModeVertex,
-    'paint': {
-      'circle-radius': 3,
-      'circle-color': '#fbb03b'
-    }
-  },
-  {
-    'id': 'gl-draw-point-point-stroke-inactive',
-    'type': 'circle',
-    'filter': deactivatedStaticModeFeature,
-    'paint': {
-      'circle-radius': 5,
-      'circle-opacity': 1,
-      'circle-color': '#fff'
-    }
-  },
-  {
-    'id': 'gl-draw-point-inactive',
-    'type': 'circle',
-    'filter': deactivatedStaticModeFeature,
-    'paint': {
-      'circle-radius': 3,
-      'circle-color': '#3bb2d0'
-    }
-  },
-  {
-    'id': 'gl-draw-point-stroke-active',
-    'type': 'circle',
-    'filter': activatedMidPoint,
-    'paint': {
-      'circle-radius': 7,
-      'circle-color': '#fff'
-    }
-  },
-  {
-    'id': 'gl-draw-point-active',
-    'type': 'circle',
-    'filter': activatedMidPoint,
-    'paint': {
-      'circle-radius': 5,
-      'circle-color': '#fbb03b'
-    }
-  },
-  {
-    'id': 'gl-draw-polygon-fill-static',
-    'type': 'fill',
-    'filter': staticPolygon,
-    'paint': {
-      'fill-color': '#3bb2d0',
-      'fill-outline-color': '#3bb2d0',
-      'fill-opacity': 0.1
-    }
-  },
-  {
-    'id': 'gl-draw-polygon-stroke-static',
-    'type': 'line',
-    'filter': staticPolygon,
-    'layout': roundLineLayout,
+/** Summarized style of a draw component */
+export interface DrawStyle {
+  color?: string;
+  opacity?: number;
+  dash?: number[];
+}
 
-    'paint': linePaint
-  },
-  {
-    'id': 'gl-draw-line-static',
-    'type': 'line',
-    'filter': ['all', ['==', 'mode', 'static'], ['==', '$type', 'LineString']],
-    'layout': roundLineLayout,
+export interface DrawTheme {
+  /** Style for active drawings */
+  active?: DrawStyle;
+  /** Style for deactivated drawings */
+  inactive?: DrawStyle;
+}
 
-    'paint': {
-      'line-color': '#404040',
-      'line-width': 2
-    }
-  },
-  {
-    'id': 'gl-draw-point-static',
-    'type': 'circle',
-    'filter': ['all', ['==', 'mode', 'static'], ['==', '$type', 'Point']],
-    'paint': {
-      'circle-radius': 5,
-      'circle-color': '#404040'
-    }
-  },
-  {
-    'id': 'gl-draw-line-rotate-point',
-    'type': 'line',
-    'filter': staticLineMidPoint,
-    'layout': roundLineLayout,
+function buildLinePaint(color: string, dash: number[]) {
+  return {
+    'line-color': color,
+    'line-dasharray': dash,
+    'line-width': 2
+  };
+}
 
-    'paint': dashedLinePaint
-  },
-  {
-    'id': 'gl-draw-polygon-rotate-point-stroke',
-    'type': 'circle',
-    'filter': rotatePointFilter,
-    'paint': {
-      'circle-radius': 4,
-      'circle-color': '#fff'
-    }
-  },
-  {
-    'id': 'gl-draw-polygon-rotate-point',
-    'type': 'circle',
-    'filter': rotatePointFilter,
-    'paint': {
-      'circle-radius': 2,
-      'circle-color': '#fbb03b'
-    }
-  },
-  {
-    'id': 'gl-draw-polygon-rotate-point-icon',
-    'type': 'symbol',
-    'filter': rotatePointFilter,
-    'layout': {
-      'icon-image': 'rotate',
-      'icon-allow-overlap': true,
-      'icon-ignore-placement': true,
-      'icon-rotation-alignment': 'map',
-      'icon-rotate': ['get', 'heading']
+/**
+ * Builds the style for the Mapbox draw layers
+ * @param theme Theme summarizing the drawing styles
+ */
+export function buildDrawStyle(theme: DrawTheme) {
+  const activeColor = theme?.active?.color ?? '#fbb03b';
+  const activeOpacity = theme?.active?.opacity ?? 0.1;
+  const activeDash = theme.active?.dash ?? [0.2, 2];
+
+  const activeLinePaint = buildLinePaint(activeColor, activeDash);
+
+  const inactiveColor = theme?.inactive?.color ?? '#3bb2d0';
+  const inactiveOpacity = theme?.inactive?.opacity ?? 0.1;
+  const inactiveDash = theme.inactive?.dash ?? [0.2, 2];
+
+  const inactiveLinePaint = buildLinePaint(inactiveColor, inactiveDash);
+
+  return [
+    {
+      'id': 'gl-draw-polygon-fill-inactive',
+      'type': 'fill',
+      'filter': deactivatedStaticPolygon,
+      'paint': {
+        'fill-color': inactiveColor,
+        'fill-outline-color': inactiveColor,
+        'fill-opacity': inactiveOpacity
+      }
     },
-    'paint': {
-      'icon-opacity': 1.0,
-      'icon-opacity-transition': {
-        'delay': 0,
-        'duration': 0
+    {
+      'id': 'gl-draw-polygon-fill-active',
+      'type': 'fill',
+      'filter': activePolygon,
+      'paint': {
+        'fill-color': activeColor,
+        'fill-outline-color': activeColor,
+        'fill-opacity': activeOpacity
+      }
+    },
+    {
+      'id': 'gl-draw-polygon-midpoint',
+      'type': 'circle',
+      'filter': ['all',
+        ['==', '$type', 'Point'],
+        ['==', 'meta', 'midpoint']],
+      'paint': {
+        'circle-radius': 3,
+        'circle-color': activeColor
+      }
+    },
+    {
+      'id': 'gl-draw-polygon-stroke-inactive',
+      'type': 'line',
+      'filter': deactivatedStaticPolygon,
+      'layout': roundLineLayout,
+      'paint': inactiveLinePaint
+    },
+    {
+      'id': 'gl-draw-polygon-stroke-active',
+      'type': 'line',
+      'filter': activePolygon,
+      'layout': roundLineLayout,
+      'paint': activeLinePaint
+    },
+    {
+      'id': 'gl-draw-line-inactive',
+      'type': 'line',
+      'filter': ['all',
+        ['==', 'active', 'false'],
+        ['==', '$type', 'LineString'],
+        ['!=', 'mode', 'static']
+      ],
+      'layout': roundLineLayout,
+      'paint': inactiveLinePaint
+    },
+    {
+      'id': 'gl-draw-line-active',
+      'type': 'line',
+      'filter': ['all',
+        ['==', '$type', 'LineString'],
+        ['==', 'active', 'true']
+      ],
+      'layout': roundLineLayout,
+      'paint': activeLinePaint
+    },
+    {
+      'id': 'gl-draw-polygon-and-line-vertex-stroke-inactive',
+      'type': 'circle',
+      'filter': staticModeVertex,
+      'paint': {
+        'circle-radius': 5,
+        'circle-color': '#fff'
+      }
+    },
+    {
+      'id': 'gl-draw-polygon-and-line-vertex-inactive',
+      'type': 'circle',
+      'filter': staticModeVertex,
+      'paint': {
+        'circle-radius': 3,
+        'circle-color': activeColor
+      }
+    },
+    {
+      'id': 'gl-draw-point-point-stroke-inactive',
+      'type': 'circle',
+      'filter': deactivatedStaticModeFeature,
+      'paint': {
+        'circle-radius': 5,
+        'circle-opacity': 1,
+        'circle-color': '#fff'
+      }
+    },
+    {
+      'id': 'gl-draw-point-inactive',
+      'type': 'circle',
+      'filter': deactivatedStaticModeFeature,
+      'paint': {
+        'circle-radius': 3,
+        'circle-color': inactiveColor
+      }
+    },
+    {
+      'id': 'gl-draw-point-stroke-active',
+      'type': 'circle',
+      'filter': activatedMidPoint,
+      'paint': {
+        'circle-radius': 7,
+        'circle-color': '#fff'
+      }
+    },
+    {
+      'id': 'gl-draw-point-active',
+      'type': 'circle',
+      'filter': activatedMidPoint,
+      'paint': {
+        'circle-radius': 5,
+        'circle-color': activeColor
+      }
+    },
+    {
+      'id': 'gl-draw-polygon-fill-static',
+      'type': 'fill',
+      'filter': staticPolygon,
+      'paint': {
+        'fill-color': inactiveColor,
+        'fill-outline-color': inactiveColor,
+        'fill-opacity': inactiveOpacity
+      }
+    },
+    {
+      'id': 'gl-draw-polygon-stroke-static',
+      'type': 'line',
+      'filter': staticPolygon,
+      'layout': roundLineLayout,
+      'paint': inactiveLinePaint
+    },
+    {
+      'id': 'gl-draw-line-static',
+      'type': 'line',
+      'filter': ['all', ['==', 'mode', 'static'], ['==', '$type', 'LineString']],
+      'layout': roundLineLayout,
+      'paint': {
+        'line-color': '#404040',
+        'line-width': 2
+      }
+    },
+    {
+      'id': 'gl-draw-point-static',
+      'type': 'circle',
+      'filter': ['all', ['==', 'mode', 'static'], ['==', '$type', 'Point']],
+      'paint': {
+        'circle-radius': 5,
+        'circle-color': '#404040'
+      }
+    },
+    {
+      'id': 'gl-draw-line-rotate-point',
+      'type': 'line',
+      'filter': staticLineMidPoint,
+      'layout': roundLineLayout,
+      'paint': activeLinePaint
+    },
+    {
+      'id': 'gl-draw-polygon-rotate-point-stroke',
+      'type': 'circle',
+      'filter': rotatePointFilter,
+      'paint': {
+        'circle-radius': 4,
+        'circle-color': '#fff'
+      }
+    },
+    {
+      'id': 'gl-draw-polygon-rotate-point',
+      'type': 'circle',
+      'filter': rotatePointFilter,
+      'paint': {
+        'circle-radius': 2,
+        'circle-color': activeColor
+      }
+    },
+    {
+      'id': 'gl-draw-polygon-rotate-point-icon',
+      'type': 'symbol',
+      'filter': rotatePointFilter,
+      'layout': {
+        'icon-image': 'rotate',
+        'icon-allow-overlap': true,
+        'icon-ignore-placement': true,
+        'icon-rotation-alignment': 'map',
+        'icon-rotate': ['get', 'heading']
+      },
+      'paint': {
+        'icon-opacity': 1,
+        'icon-opacity-transition': {
+          'delay': 0,
+          'duration': 0
+        }
+      }
+    },
+    {
+      'id': 'gl-draw-line-resize-point',
+      'type': 'line',
+      'filter': staticLineMidPoint,
+      'layout': roundLineLayout,
+      'paint': activeLinePaint
+    },
+    {
+      'id': 'gl-draw-polygon-resize-point-stroke',
+      'type': 'circle',
+      'filter': staticMidpoint,
+      'paint': {
+        'circle-radius': 5,
+        'circle-color': '#fff'
+      }
+    },
+    {
+      'id': 'gl-draw-polygon-resize-point',
+      'type': 'circle',
+      'filter': staticMidpoint,
+      'paint': {
+        'circle-radius': 6,
+        'circle-color': activeColor
+      }
+    },
+    {
+      'id': 'gl-draw-polygon-resize-point-icon',
+      'type': 'symbol',
+      'filter': staticMidpoint,
+      'layout': {
+        'icon-image': 'resize',
+        'icon-allow-overlap': true,
+        'icon-ignore-placement': true,
+        'icon-rotation-alignment': 'map',
+        'icon-rotate': ['get', 'heading']
+      },
+      'paint': {
+        'icon-opacity': 1,
+        'icon-opacity-transition': {
+          'delay': 0,
+          'duration': 0
+        }
       }
     }
-  },
-  {
-    'id': 'gl-draw-line-resize-point',
-    'type': 'line',
-    'filter': staticLineMidPoint,
-    'layout': roundLineLayout,
-
-    'paint': dashedLinePaint
-  },
-  {
-    'id': 'gl-draw-polygon-resize-point-stroke',
-    'type': 'circle',
-    'filter': staticMidpoint,
-    'paint': {
-      'circle-radius': 5,
-      'circle-color': '#fff'
-    }
-  },
-  {
-    'id': 'gl-draw-polygon-resize-point',
-    'type': 'circle',
-    'filter': staticMidpoint,
-    'paint': {
-      'circle-radius': 6,
-      'circle-color': '#fbb03b'
-    }
-  },
-  {
-    'id': 'gl-draw-polygon-resize-point-icon',
-    'type': 'symbol',
-    'filter': staticMidpoint,
-    'layout': {
-      'icon-image': 'resize',
-      'icon-allow-overlap': true,
-      'icon-ignore-placement': true,
-      'icon-rotation-alignment': 'map',
-      'icon-rotate': ['get', 'heading']
-    },
-    'paint': {
-      'icon-opacity': 1.0,
-      'icon-opacity-transition': {
-        'delay': 0,
-        'duration': 0
-      }
-    }
-  }
-];
+  ];
+}

--- a/projects/arlas-map/src/public-api.ts
+++ b/projects/arlas-map/src/public-api.ts
@@ -48,7 +48,7 @@ export { simpleSelectModeOverride } from './lib/draw/modes/simpleSelectOverride'
 export { stripDirectSelectMode } from './lib/draw/modes/strip/strip.direct.mode';
 export { stripMode } from './lib/draw/modes/strip/strip.mode';
 export { validGeomDrawPolygonMode } from './lib/draw/modes/ValidGeomDrawPolygonMode';
-export * as styles from './lib/draw/themes/default-theme';
+export { buildDrawStyle, DrawTheme } from './lib/draw/themes/default-theme';
 export { FormatLegendPipe } from './lib/legend/format-legend.pipe';
 export { LayerIdToName } from './lib/legend/layer-name.pipe';
 export { LayerIconComponent } from './lib/legend/legend-icon/layer-icon.component';

--- a/src/app/mapgl-demo/mapgl-demo.component.html
+++ b/src/app/mapgl-demo/mapgl-demo.component.html
@@ -40,6 +40,7 @@
     (onPolygonSelect)="polygonSelect($event)" [drawOption]="drawOptions" [drawData]="drawData" [drawButtonEnabled]="true"
     [drawPolygonVerticesLimit]="5" [transformRequest]="transformRequest" (onAoiChanged)="onAoiChanged($event)"
     [visualisationSetsConfig]="visualisationSets" [visibilityUpdater]="visibilityUpdater"
-    (onMapLoaded)="onMapLoaded()" [dataSources]="mapDataSources" [enableGlobe]="true" (onMove)="onMove($event)">
+    (onMapLoaded)="onMapLoaded()" [dataSources]="mapDataSources" [enableGlobe]="true" (onMove)="onMove($event)"
+    [drawTheme]="drawTheme">
   </arlas-map>
 </div>

--- a/src/app/mapgl-demo/mapgl-demo.component.ts
+++ b/src/app/mapgl-demo/mapgl-demo.component.ts
@@ -24,7 +24,7 @@ import { MatButton, MatIconButton } from '@angular/material/button';
 import { MatDialog } from '@angular/material/dialog';
 import { MatIcon } from '@angular/material/icon';
 import { MatRadioButton, MatRadioGroup } from '@angular/material/radio';
-import { BboxGeneratorComponent } from 'arlas-map';
+import { BboxGeneratorComponent, DrawTheme } from 'arlas-map';
 import { LngLatBounds } from 'maplibre-gl';
 import { Subject } from 'rxjs';
 import { ArlasMapFrameworkService } from '../../../projects/arlas-map/src/lib/arlas-map-framework.service';
@@ -83,6 +83,15 @@ export class MapglDemoComponent<L, S, M> {
     'type': 'FeatureCollection',
     'features': []
   } as any;
+
+  public drawTheme: DrawTheme = {
+    active: {
+      color: '#ff0000'
+    },
+    inactive: {
+      color: '#00ff00'
+    }
+  }
 
   private readonly mapFrameworkService = inject(ArlasMapFrameworkService);
   private readonly dialog = inject(MatDialog);


### PR DESCRIPTION
- Add the tools for gisaia/ARLAS-wui#1119

Because of the amount of layers that need to be configured for the draw, I chose to only allow to specify the color, opacity and dasharray for active (currently drawing or editing) and inactive polygons (drawn).

Other parameters that could be added:
- vertices width (active and inactive)
- line width (active and inactive)

For the review, I suggest hiding whitespace changes to remove indent changes